### PR TITLE
Use current page for cache key

### DIFF
--- a/index.php
+++ b/index.php
@@ -87,7 +87,7 @@ $page_slug  = ( false !== $page_for_posts_id ) ? get_post_field( 'post_name', $p
 					);
 
 					// Definir la clave de caché para la consulta.
-					$cache_key = 'smile_web_recent_posts_' . $paged;
+					$cache_key = 'smile_web_recent_posts_' . $current_page;
 
 					// Intentar obtener los posts desde el caché.
 					$recent_posts = wp_cache_get( $cache_key );


### PR DESCRIPTION
## Summary
- build recent posts cache key using current page value instead of global paged

## Testing
- `php -l index.php`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bea4dec34083308f4f1813413c0808