### PR TITLE
Remove session start and sanitize title attributes

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -20,7 +20,7 @@ get_header();
 				<nav aria-label="breadcrumb">
 					<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="bg-light breadcrumb">
 						<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
-							<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php bloginfo( 'title' ); ?>">
+                                                        <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>">
 								<span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span>
 							</a>
 							<meta itemprop="position" content="1" />

--- a/page-fullwidth.php
+++ b/page-fullwidth.php
@@ -22,7 +22,7 @@ get_header();
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
 				<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb">
-					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php bloginfo( 'title' ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a><meta itemprop="position" content="1" />
+                                        <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a><meta itemprop="position" content="1" />
 					</li>
 					<?php if ( $post->post_parent ) { ?>
 					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">

--- a/page-sidebar.php
+++ b/page-sidebar.php
@@ -14,7 +14,7 @@ get_header();
 			<div id="breadcrumbs">
 				<nav aria-label="breadcrumb">
 					<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="bg-light2 breadcrumb">
-						<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php bloginfo( 'title' ); ?>"><span itemprop="name">Inicio</span></a>
+                                                <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name">Inicio</span></a>
 							<meta itemprop="position" content="1" />
 						</li>
 						<?php if ( $post->post_parent ) { ?>

--- a/page.php
+++ b/page.php
@@ -47,7 +47,7 @@ get_header();
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
 				<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="bg-light breadcrumb">
-					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php bloginfo( 'title' ); ?>"><span itemprop="name">Inicio</span></a>
+                                        <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name">Inicio</span></a>
 						<meta itemprop="position" content="1">
 					</li>
 					<?php if ( is_page() && 0 < $post->post_parent ) : ?>

--- a/search.php
+++ b/search.php
@@ -7,7 +7,6 @@
  * @package smile-web
  */
 
-session_start();
 get_header();
 ?>
 <section id="intro">
@@ -23,7 +22,7 @@ get_header();
 		<div id="breadcrumbs" class="pb-4">
 			<nav aria-label="breadcrumb">
 				<ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb bg-light">
-					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php bloginfo( 'title' ); ?>"><span itemprop="name">
+                                        <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name">
 					<?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 						<meta itemprop="position" content="1" />
 					</li>
@@ -37,7 +36,7 @@ get_header();
 		<hr>
 		<div class="row">
 			<p><?php esc_html_e( 'Do you want to search again?', 'smile-web' ); ?></p>
-			<a id="myBtn2" href="#" class="btn-cta m-2 buscar jquery" aria-label="Abrir buscador" itemprop="url" data-bs-toggle="modal" data-bs-target="#searchModal" rel="nofollow noopener noreferrer"><span title="busca en la web" aria-hidden="true"></span> <?php esc_html_e( 'Search again', 'smile-web' ); ?></a>
+                        <a id="myBtn2" href="#" class="btn-cta m-2 buscar jquery" aria-label="<?php echo esc_attr__( 'Open search', 'smile-web' ); ?>" itemprop="url" data-bs-toggle="modal" data-bs-target="#searchModal" rel="nofollow noopener noreferrer"><span title="busca en la web" aria-hidden="true"></span> <?php esc_html_e( 'Search again', 'smile-web' ); ?></a>
 		</div>
 		<hr>
 		<?php if ( have_posts() ) : ?>


### PR DESCRIPTION
## Summary
- remove unnecessary `session_start()` from search template
- escape site title in breadcrumb link attributes
- localize search modal label with `esc_attr__`

## Testing
- `php -l search.php page.php archive.php page-sidebar.php page-fullwidth.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bea60802048330a9265a20bfc7dc8b