### PR TITLE
Sanitize title attributes and add theme fallback image

### DIFF
--- a/404.php
+++ b/404.php
@@ -41,19 +41,19 @@ get_header();
 							while ( $recent_posts->have_posts() ) :
 								$recent_posts->the_post();
 								?>
-								<article class="col-md-6 mb-4">
-									<figure class="shadow">
-										<a href="<?php the_permalink(); ?>" title="<?php the_title(); ?>">
-											<img class="img-fluid" src="<?php echo has_post_thumbnail() ? esc_url( get_the_post_thumbnail_url() ) : 'ruta/de/imagen/por/defecto.jpg'; ?>" alt="<?php the_title(); ?>" title="<?php the_title(); ?>" width="600" height="400">
-										</a>
-										<figcaption class="bg-white px-4">
-											<p class="lead">
-												<a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php the_title(); ?>"><?php the_title(); ?></a>
-											</p>
-											<p><?php echo esc_html( wp_trim_words( get_the_excerpt(), 20, '...' ) ); ?></p>
-										</figcaption>
-									</figure>
-								</article>
+                                                                <article class="col-md-6 mb-4">
+                                                                        <figure class="shadow">
+                                                                                <a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>">
+                                                                                        <img class="img-fluid" src="<?php echo has_post_thumbnail() ? esc_url( get_the_post_thumbnail_url() ) : esc_url( get_template_directory_uri() . '/assets/img/thumbnail-header.jpg' ); ?>" alt="<?php echo esc_attr( get_the_title() ); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" width="600" height="400">
+                                                                                </a>
+                                                                                <figcaption class="bg-white px-4">
+                                                                                        <p class="lead">
+                                                                                                <a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a>
+                                                                                        </p>
+                                                                                        <p><?php echo esc_html( wp_trim_words( get_the_excerpt(), 20, '...' ) ); ?></p>
+                                                                                </figcaption>
+                                                                        </figure>
+                                                                </article>
 								<?php
 							endwhile;
 							?>

--- a/page-fullwidth.php
+++ b/page-fullwidth.php
@@ -117,7 +117,7 @@ if ( is_page() && $post->post_parent ) {
 			$recent->the_post();
 			?>
 			<article class="blog-col col-md-4 col-sm-6 mb-4 mx-0">
-				<figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>"  title="<?php the_title(); ?>"  rel="nofollow">
+				<figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>"  title="<?php echo esc_attr( get_the_title() ); ?>"  rel="nofollow">
 							<?php
 							if ( has_post_thumbnail() ) {
 								$attachment_id = get_post_thumbnail_id( get_the_ID() );
@@ -137,7 +137,7 @@ if ( is_page() && $post->post_parent ) {
 							}
 							?>
 							</a>
-					<figcaption id="post-<?php the_ID(); ?>" class="p-4"><h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php the_title(); ?>"><?php the_title(); ?></a></h4><p><?php the_excerpt(); ?></p><hr>
+					<figcaption id="post-<?php the_ID(); ?>" class="p-4"><h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4><p><?php the_excerpt(); ?></p><hr>
 					<p><?php if ( ( get_the_modified_date( 'j F, Y' ) ) === ( get_the_date( 'j F, Y' ) ) ) { ?>
 						<span><b><?php esc_html_e( 'Published', 'smile-web' ); ?></b>: <?php the_modified_date( 'j F, Y' ); ?></span>
 					<?php } else { ?>

--- a/page-sidebar.php
+++ b/page-sidebar.php
@@ -133,9 +133,9 @@ get_header();
 					$recent->the_post();
 					?>
 					<article class="blog-col col-md-4 col-sm-6 mb-4 mx-0">
-						<figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php the_title(); ?>" rel="nofollow"><img class="img-fluid" src="<?php the_post_thumbnail_url(); ?>" alt="<?php $thumb_alt; ?>"></a>
+						<figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow"><img class="img-fluid" src="<?php the_post_thumbnail_url(); ?>" alt="<?php $thumb_alt; ?>"></a>
 							<figcaption id="post-<?php the_ID(); ?>" class="p-4 text-white">
-								<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php the_title(); ?>"><?php the_title(); ?></a></h4>
+								<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
 								<p><?php the_excerpt(); ?></p>
 								<hr>
 								<p><?php if ( ( get_the_modified_date( 'j F, Y' ) ) === ( get_the_date( 'j F, Y' ) ) ) { ?>

--- a/page.php
+++ b/page.php
@@ -151,7 +151,7 @@ get_header();
 						?>
 						<article class="blog-col col-md-4 col-sm-6 mb-4 mx-0">
 							<figure class="mb-0 shadow">
-								<a href="<?php the_permalink(); ?>" title="<?php the_title(); ?>" rel="nofollow">
+								<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
 									<?php
 									if ( has_post_thumbnail() ) :
 										$attachment_id = get_post_thumbnail_id( get_the_ID() );
@@ -168,7 +168,7 @@ get_header();
 									<?php endif; ?>
 								</a>
 								<figcaption id="post-<?php the_ID(); ?>" class="p-4">
-									<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php the_title(); ?>"><?php the_title(); ?></a></h4>
+									<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
 									<p><?php the_excerpt(); ?></p>
 									<hr>
 									<p>

--- a/single.php
+++ b/single.php
@@ -202,7 +202,7 @@ get_header();
 					?>
 					<article class="blog-col col-md-4 col-sm-6 mb-4 mx-0">
 						<figure class="mb-0 shadow">
-							<a href="<?php the_permalink(); ?>" title="<?php the_title(); ?>" rel="nofollow">
+							<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
 								<?php
 								if ( has_post_thumbnail() ) {
 									$attachment_id = get_post_thumbnail_id( get_the_ID() );
@@ -221,7 +221,7 @@ get_header();
 								?>
 								</a>
 							<figcaption id="post-<?php the_ID(); ?>" class="p-4">
-								<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php the_title(); ?>"><?php the_title(); ?></a></h4>
+								<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
 								<p><?php the_excerpt(); ?></p><hr>
 								<p>
 									<?php if ( get_the_modified_date( 'j F, Y' ) === get_the_date( 'j F, Y' ) ) : ?>

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -65,9 +65,9 @@
 				?>
 				<article class="blog-col col-md-6 mb-4 mx-0">
 					<div class="category shadow rounded"><a href='<?php the_category(); ?>'><?php the_category(); ?></a></div>
-					<figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php the_title(); ?>" rel="nofollow"><img class="img-fluid" src="<?php the_post_thumbnail_url(); ?>" alt="<?php $thumb_alt; ?>"></a>
+					<figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow"><img class="img-fluid" src="<?php the_post_thumbnail_url(); ?>" alt="<?php $thumb_alt; ?>"></a>
 						<figcaption id="post-<?php the_ID(); ?>" class="p-4">
-							<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php the_title(); ?>"><?php the_title(); ?></a></h4>
+							<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
 							<p><?php the_excerpt(); ?></p>
 							<hr>
 							<p><?php if ( ( get_the_modified_date( 'j F, Y' ) ) === ( get_the_date( 'j F, Y' ) ) ) { ?>

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -22,12 +22,12 @@
 		else :
 			?>
         <article class="blog-col col-lg-6 mb-4 mx-0">
-            <figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php the_title(); ?>"
+            <figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>"
                     rel="nofollow"><img class="img-fluid" src="<?php the_post_thumbnail_url(); ?>"
                         alt="<?php $thumb_alt; ?>"></a>
                 <figcaption id="post-<?php the_ID(); ?>" class="p-4">
                     <h4><a href="<?php the_permalink(); ?>" rel="bookmark"
-                            title="<?php the_title(); ?>"><?php the_title(); ?></a></h4>
+                            title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
                     <p><?php the_excerpt(); ?></p>
                     <hr>
                     <p><?php if ( ( get_the_modified_date( 'j F, Y' ) ) === ( get_the_date( 'j F, Y' ) ) ) { ?>


### PR DESCRIPTION
## Summary
- Use a theme image as the 404 fallback thumbnail, escaped with `esc_url()` and `get_template_directory_uri()`
- Escape post titles in HTML attributes with `esc_attr( get_the_title() )` across templates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:js` *(fails: wp-scripts: not found)*
- `npm install` *(fails: node-sass build missing Python distutils)*
- `php -l 404.php page-fullwidth.php page-sidebar.php page.php single.php template-parts/content.php template-parts/content-none.php`


------
https://chatgpt.com/codex/tasks/task_e_68bea6ddd05c8330b99f5927c5ccd944