### PR TITLE
Escape category links and featured image output

### DIFF
--- a/404.php
+++ b/404.php
@@ -44,7 +44,15 @@ get_header();
                                                                 <article class="col-md-6 mb-4">
                                                                         <figure class="shadow">
                                                                                 <a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>">
-                                                                                        <img class="img-fluid" src="<?php echo has_post_thumbnail() ? esc_url( get_the_post_thumbnail_url() ) : esc_url( get_template_directory_uri() . '/assets/img/thumbnail-header.jpg' ); ?>" alt="<?php echo esc_attr( get_the_title() ); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" width="600" height="400">
+                                                                                        <?php
+                                                                                        $thumb_url = has_post_thumbnail() ? get_the_post_thumbnail_url( get_the_ID(), 'full' ) : get_template_directory_uri() . '/assets/img/thumbnail-header.jpg';
+                                                                                        $thumb_id  = get_post_thumbnail_id();
+                                                                                        $thumb_alt = $thumb_id ? get_post_meta( $thumb_id, '_wp_attachment_image_alt', true ) : '';
+                                                                                        if ( empty( $thumb_alt ) ) {
+                                                                                                $thumb_alt = get_the_title();
+                                                                                        }
+                                                                                        ?>
+                                                                                        <img class="img-fluid" src="<?php echo esc_url( $thumb_url ); ?>" alt="<?php echo esc_attr( $thumb_alt ); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" width="600" height="400">
                                                                                 </a>
                                                                                 <figcaption class="bg-white px-4">
                                                                                         <p class="lead">

--- a/front-page.php
+++ b/front-page.php
@@ -98,43 +98,51 @@ if ( 'yes' === $show_header_image && ! empty( $header_image ) ) {
 					while ( $recent_posts->have_posts() ) :
 						$recent_posts->the_post();
 						?>
-						<article <?php post_class( 'blog-col col-md-4 mb-4 mx-0' ); ?>>
-							<div class="category">
-								<?php the_category(); ?>
-							</div>
+                                                <article <?php post_class( 'blog-col col-md-4 mb-4 mx-0' ); ?>>
+                                                        <div class="category">
+                                                                <?php
+                                                                $categories = get_the_category();
+                                                                if ( $categories ) {
+                                                                        foreach ( $categories as $category ) {
+                                                                                printf(
+                                                                                        '<a href="%1$s">%2$s</a>',
+                                                                                        esc_url( get_category_link( $category->term_id ) ),
+                                                                                        esc_html( $category->name )
+                                                                                );
+                                                                        }
+                                                                }
+                                                                ?>
+                                                        </div>
 
-							<figure class="shadow">
-								<a
-									href="<?php the_permalink(); ?>"
-									title="<?php echo esc_attr( get_the_title() ); ?>"
-									rel="nofollow"
-								>
-									<?php
-									if ( has_post_thumbnail() ) {
-										the_post_thumbnail(
-											'medium',
-											array(
-												'class' => 'img-fluid',
-												'alt'   => esc_attr( get_the_title() ),
-											)
-										);
-									} elseif ( ! empty( $blog_post_default_img ) ) {
-										// Default image set in the Customizer.
-										printf(
-											'<img src="%1$s" class="img-fluid" alt="%2$s" width="1000" height="667" />',
-											esc_url( $blog_post_default_img ),
-											esc_attr( get_bloginfo( 'name' ) )
-										);
-									} else {
-										// Fallback to theme asset.
-										printf(
-											'<img src="%1$s/assets/img/thumbnail-header.jpg" class="img-fluid" alt="%2$s" width="1000" height="667" />',
-											esc_url( get_template_directory_uri() ),
-											esc_attr( get_bloginfo( 'name' ) )
-										);
-									}
-									?>
-								</a>
+                                                        <figure class="shadow">
+                                                                <a
+                                                                        href="<?php the_permalink(); ?>"
+                                                                        title="<?php echo esc_attr( get_the_title() ); ?>"
+                                                                        rel="nofollow"
+                                                                >
+                                                                        <?php
+                                                                        if ( has_post_thumbnail() ) {
+                                                                                $thumb_url = get_the_post_thumbnail_url( get_the_ID(), 'medium' );
+                                                                                $thumb_id  = get_post_thumbnail_id();
+                                                                                $thumb_alt = get_post_meta( $thumb_id, '_wp_attachment_image_alt', true );
+                                                                                if ( empty( $thumb_alt ) ) {
+                                                                                        $thumb_alt = get_the_title();
+                                                                                }
+                                                                        } elseif ( ! empty( $blog_post_default_img ) ) {
+                                                                                $thumb_url = $blog_post_default_img;
+                                                                                $thumb_alt = get_bloginfo( 'name' );
+                                                                        } else {
+                                                                                $thumb_url = get_template_directory_uri() . '/assets/img/thumbnail-header.jpg';
+                                                                                $thumb_alt = get_bloginfo( 'name' );
+                                                                        }
+
+                                                                        printf(
+                                                                                '<img src="%1$s" class="img-fluid" alt="%2$s" width="1000" height="667" />',
+                                                                                esc_url( $thumb_url ),
+                                                                                esc_attr( $thumb_alt )
+                                                                        );
+                                                                        ?>
+                                                                </a>
 
 								<figcaption class="bg-white px-4">
 									<p class="lead">

--- a/index.php
+++ b/index.php
@@ -108,36 +108,54 @@ $page_slug  = ( false !== $page_for_posts_id ) ? get_post_field( 'post_name', $p
 								while ( $recent_posts->have_posts() ) :
 									$recent_posts->the_post();
 									?>
-									<article class="blog-col col-md-6 mb-4 mx-0">
-										<div class="category">
-											<?php the_category(); // Mostrar categorías. ?>
-										</div>
-										<figure class="shadow">
-											<a href="<?php the_permalink(); ?>"
-												title="<?php echo esc_attr( get_the_title() ); ?>"
-												rel="nofollow">
-												<?php
-													// Obtener la imagen configurada en el Customizer.
-													$blog_default_image = get_theme_mod( 'blog_default_image' );
+                                                                        <article class="blog-col col-md-6 mb-4 mx-0">
+                                                                                <div class="category">
+                                                                                        <?php
+                                                                                        $categories = get_the_category();
+                                                                                        if ( $categories ) {
+                                                                                                foreach ( $categories as $category ) {
+                                                                                                        printf(
+                                                                                                                '<a href="%1$s">%2$s</a>',
+                                                                                                                esc_url( get_category_link( $category->term_id ) ),
+                                                                                                                esc_html( $category->name )
+                                                                                                        );
+                                                                                                }
+                                                                                        }
+                                                                                        ?>
+                                                                                </div>
+                                                                                <figure class="shadow">
+                                                                                        <a href="<?php the_permalink(); ?>"
+                                                                                                title="<?php echo esc_attr( get_the_title() ); ?>"
+                                                                                                rel="nofollow">
+                                                                                                <?php
+                                                                                                // Obtener la imagen configurada en el Customizer.
+                                                                                                $blog_default_image = get_theme_mod( 'blog_default_image' );
 
-													// Si la opción está vacía, se asigna la ruta por defecto.
-												if ( empty( $blog_default_image ) ) {
-													$blog_default_image = get_template_directory_uri() . '/assets/img/thumbnail-header.jpg';
-												}
-												?>
+                                                                                                // Si la opción está vacía, se asigna la ruta por defecto.
+                                                                                                if ( empty( $blog_default_image ) ) {
+                                                                                                        $blog_default_image = get_template_directory_uri() . '/assets/img/thumbnail-header.jpg';
+                                                                                                }
 
-												<img class="img-fluid"
-													src="<?php echo ( has_post_thumbnail() ) ? esc_url( get_the_post_thumbnail_url() ) : esc_url( $blog_default_image ); ?>"
-													alt="<?php echo esc_attr( get_the_title() ); ?>"
-													title="<?php echo esc_attr( get_the_title() ); ?>"
-													width="600"
-													height="400">
-											</a>
-											<figcaption class="bg-white px-4">
-												<p class="lead">
-													<a href="<?php the_permalink(); ?>"
-														rel="bookmark"
-														title="<?php echo esc_attr( get_the_title() ); ?>">
+                                                                                                $thumb_url = has_post_thumbnail() ? get_the_post_thumbnail_url( get_the_ID(), 'full' ) : $blog_default_image;
+                                                                                                $thumb_id  = get_post_thumbnail_id();
+                                                                                                $thumb_alt = $thumb_id ? get_post_meta( $thumb_id, '_wp_attachment_image_alt', true ) : '';
+                                                                                                if ( empty( $thumb_alt ) ) {
+                                                                                                        $thumb_alt = get_the_title();
+                                                                                                }
+                                                                                                ?>
+
+                                                                                                <img class="img-fluid"
+                                                                                                        src="<?php echo esc_url( $thumb_url ); ?>"
+                                                                                                        alt="<?php echo esc_attr( $thumb_alt ); ?>"
+                                                                                                        title="<?php echo esc_attr( get_the_title() ); ?>"
+                                                                                                        width="600"
+                                                                                                        height="400">
+                                                                                        </a>
+                                                                                        <figcaption class="bg-white px-4">
+                                                                                                <p class="lead">
+                                                                                                        <a href="<?php the_permalink(); ?>"
+                                                                                                                rel="bookmark"
+                                                                                                                title="<?php echo esc_attr( get_the_title() ); ?>">
 														<?php echo esc_html( get_the_title() ); ?>
 													</a>
 												</p>

--- a/page-sidebar.php
+++ b/page-sidebar.php
@@ -133,11 +133,21 @@ get_header();
 					$recent->the_post();
 					?>
 					<article class="blog-col col-md-4 col-sm-6 mb-4 mx-0">
-						<figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow"><img class="img-fluid" src="<?php the_post_thumbnail_url(); ?>" alt="<?php $thumb_alt; ?>"></a>
-							<figcaption id="post-<?php the_ID(); ?>" class="p-4 text-white">
-								<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
-								<p><?php the_excerpt(); ?></p>
-								<hr>
+                                                <figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
+                                                        <?php
+                                                        $thumb_url = get_the_post_thumbnail_url( get_the_ID(), 'full' );
+                                                        $thumb_id  = get_post_thumbnail_id();
+                                                        $thumb_alt = $thumb_id ? get_post_meta( $thumb_id, '_wp_attachment_image_alt', true ) : '';
+                                                        if ( empty( $thumb_alt ) ) {
+                                                                $thumb_alt = get_the_title();
+                                                        }
+                                                        ?>
+                                                        <img class="img-fluid" src="<?php echo esc_url( $thumb_url ); ?>" alt="<?php echo esc_attr( $thumb_alt ); ?>">
+                                                </a>
+                                                <figcaption id="post-<?php the_ID(); ?>" class="p-4 text-white">
+                                                        <h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
+                                                        <p><?php the_excerpt(); ?></p>
+                                                        <hr>
 								<p><?php if ( ( get_the_modified_date( 'j F, Y' ) ) === ( get_the_date( 'j F, Y' ) ) ) { ?>
 										<span><b><?php esc_html_e( 'Published', 'smile-web' ); ?></b>: <?php the_modified_date( 'j F, Y' ); ?></span>
 									<?php } else { ?>

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -63,10 +63,33 @@
 			while ( $recent->have_posts() ) :
 				$recent->the_post();
 				?>
-				<article class="blog-col col-md-6 mb-4 mx-0">
-					<div class="category shadow rounded"><a href='<?php the_category(); ?>'><?php the_category(); ?></a></div>
-					<figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow"><img class="img-fluid" src="<?php the_post_thumbnail_url(); ?>" alt="<?php $thumb_alt; ?>"></a>
-						<figcaption id="post-<?php the_ID(); ?>" class="p-4">
+                                <article class="blog-col col-md-6 mb-4 mx-0">
+                                        <div class="category shadow rounded">
+                                                <?php
+                                                $categories = get_the_category();
+                                                if ( $categories ) {
+                                                        foreach ( $categories as $category ) {
+                                                                printf(
+                                                                        '<a href="%1$s">%2$s</a>',
+                                                                        esc_url( get_category_link( $category->term_id ) ),
+                                                                        esc_html( $category->name )
+                                                                );
+                                                        }
+                                                }
+                                                ?>
+                                        </div>
+                                        <figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
+                                                <?php
+                                                $thumb_url = get_the_post_thumbnail_url( get_the_ID(), 'full' );
+                                                $thumb_id  = get_post_thumbnail_id();
+                                                $thumb_alt = $thumb_id ? get_post_meta( $thumb_id, '_wp_attachment_image_alt', true ) : '';
+                                                if ( empty( $thumb_alt ) ) {
+                                                        $thumb_alt = get_the_title();
+                                                }
+                                                ?>
+                                                <img class="img-fluid" src="<?php echo esc_url( $thumb_url ); ?>" alt="<?php echo esc_attr( $thumb_alt ); ?>">
+                                        </a>
+                                                <figcaption id="post-<?php the_ID(); ?>" class="p-4">
 							<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
 							<p><?php the_excerpt(); ?></p>
 							<hr>


### PR DESCRIPTION
## Summary
- Render category links using `get_the_category()` and `get_category_link()` with proper escaping
- Retrieve featured images with `esc_url()` and alt text via `esc_attr()`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:js` *(fails: wp-scripts not found)*
- `npm run lint:scss` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beab3f29dc833085e3c7e363943170