### PR TITLE
Avoid double escaping of Customizer CSS

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -50,9 +50,9 @@ add_action( 'wp_enqueue_scripts', 'smile_web_add_dynamic_styles' );
  * Outputs custom CSS stored via the Customizer.
  */
 function smile_v6_custom_css_output() {
-	$custom_css = wp_get_custom_css();
-	if ( ! empty( $custom_css ) ) {
-		echo '<style type="text/css">' . esc_html( $custom_css ) . '</style>';
-	}
+        $custom_css = wp_get_custom_css();
+        if ( ! empty( $custom_css ) ) {
+                echo '<style type="text/css">' . wp_strip_all_tags( $custom_css ) . '</style>';
+        }
 }
 add_action( 'wp_head', 'smile_v6_custom_css_output' );


### PR DESCRIPTION
## Summary
- Replace `esc_html` with `wp_strip_all_tags` when printing Customizer CSS from `wp_get_custom_css()`

## Testing
- `php -l inc/customizer-dynamic-styles.php`
- `npm run lint:js` *(fails: wp-scripts not found)*
- `npm run lint:scss` *(fails: wp-scripts not found)*
- `npm install --no-audit --no-fund` *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_68beac4b0a648330a6798a3672305ed3