### PR TITLE
Fix intro section closing tag in search template

### DIFF
--- a/search.php
+++ b/search.php
@@ -15,7 +15,7 @@ get_header();
 	<h1 class="page-title"> <?php echo esc_html( get_search_query() ); ?> </h1>
 </div><!-- .page-header -->
 
-</div>
+</section>
 <!-- #intro -->
 <main id="main" class="search-page pt-4 pb-4 bg-light">
 	<div class="container">


### PR DESCRIPTION
## Summary
- replace stray closing div with section in search template

## Testing
- php -l search.php
- npm install (fails: ModuleNotFoundError: No module named 'distutils')
- npm run lint:js (fails: wp-scripts: not found)
- npm run lint:scss (fails: wp-scripts: not found)


------
https://chatgpt.com/codex/tasks/task_e_68beb0e7be288330968325991df5bbd1