### PR TITLE
Replace Spanish strings with English equivalents

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -174,7 +174,7 @@
 				</div>
 				<?php
 				/* translators: 1: Theme name, 2: Theme author URL. */
-                                printf( esc_html__( 'Theme: %1$s by %2$s.', 'smile-web' ), 'SMiLE web', '<a href="' . esc_url( 'https://smilecomunicacion.com/web/wordpress/smile-web/' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'SMiLE Comunicación', 'smile-web' ) . '</a>' );
+                               printf( esc_html__( 'Theme: %1$s by %2$s.', 'smile-web' ), 'SMiLE web', '<a href="' . esc_url( 'https://smilecomunicacion.com/web/wordpress/smile-web/' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'SMiLE Communication', 'smile-web' ) . '</a>' );
                                 ?>
                         </div>
                 </div>
@@ -191,11 +191,11 @@
 		</div>
 		<div class="modal-body bg-light">
 			<form action="<?php echo esc_url( home_url( '/' ) ); ?>" method="get" class="row">
-				<input type="text" class="searching_TopHeader-Lupa-Buscador py-2 col-10 col-md-11 form-control" name="s" id="myInput" onkeyup="fetch()" placeholder="<?php esc_attr_e( 'Escribe aquí', 'smile-web' ); ?>">
-				<button type="submit" class="col-2">
-					<span class="dashicons dashicons-search" aria-hidden="true"></span>
-					<span class="screen-reader-text"><?php esc_html_e( 'Buscar', 'smile-web' ); ?></span>
-				</button>
+                               <input type="text" class="searching_TopHeader-Lupa-Buscador py-2 col-10 col-md-11 form-control" name="s" id="myInput" onkeyup="fetch()" placeholder="<?php esc_attr_e( 'Write here', 'smile-web' ); ?>">
+                               <button type="submit" class="col-2">
+                                       <span class="dashicons dashicons-search" aria-hidden="true"></span>
+                                       <span class="screen-reader-text"><?php esc_html_e( 'Search', 'smile-web' ); ?></span>
+                               </button>
 				<div id="resultado" class="col-12">
 					<!-- Aquí se mostrarán los resultados -->
 				</div>

--- a/index.php
+++ b/index.php
@@ -22,7 +22,7 @@ $page_slug  = ( false !== $page_for_posts_id ) ? get_post_field( 'post_name', $p
 		<h1><?php echo esc_html( $page_title ); ?></h1>
 		<p class="text-center mt-4">
 			<a href="#contact" class="btn-cta" rel="nofollow noreferrer">
-				<?php esc_html_e( 'Contáctanos', 'smile-web' ); ?>
+                               <?php esc_html_e( 'Contact us', 'smile-web' ); ?>
 			</a>
 		</p>
 	</div>

--- a/languages/smile-web.pot
+++ b/languages/smile-web.pot
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 SMiLE Comunicación
+# Copyright (C) 2025 SMiLE Communication
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
@@ -30,8 +30,8 @@ msgid "Free theme, SEO optimized. Gain visibility and reach the top positions in
 msgstr ""
 
 #. Author of the theme
-#: style.css
-msgid "SMiLE Comunicación"
+#: style.css footer.php:177
+msgid "SMiLE Communication"
 msgstr ""
 
 #. Author URI of the theme
@@ -63,6 +63,10 @@ msgstr ""
 #: single.php:84
 #: single.php:86
 msgid "Home"
+msgstr ""
+
+#: index.php:25
+msgid "Contact us"
 msgstr ""
 
 #: archive.php:55
@@ -143,9 +147,6 @@ msgstr ""
 msgid "Write here"
 msgstr ""
 
-#: footer.php:208
-msgid "Write in the field and click on search"
-msgstr ""
 
 #: front-page.php:16
 msgid "Recent Posts"
@@ -542,7 +543,7 @@ msgid "Last articles: %s"
 msgstr ""
 
 #: search.php:15
-msgid "Búsqueda:"
+msgid "Search:"
 msgstr ""
 
 #: search.php:30
@@ -587,7 +588,7 @@ msgid "Related articles"
 msgstr ""
 
 #: template-parts/content-none.php:12
-msgid "No hay resultados"
+msgid "No results found"
 msgstr ""
 
 #. translators: 1: link to WP admin new post page.

--- a/search.php
+++ b/search.php
@@ -11,7 +11,7 @@ get_header();
 ?>
 <section id="intro">
 <div class="container">
-	<p class="lead mt-4"> <?php esc_html_e( 'Búsqueda:', 'smile-web' ); ?> </p>
+       <p class="lead mt-4"> <?php esc_html_e( 'Search:', 'smile-web' ); ?> </p>
 	<h1 class="page-title"> <?php echo esc_html( get_search_query() ); ?> </h1>
 </div><!-- .page-header -->
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: SMiLE Web
 Theme URI: https://smilecomunicacion.com/web/wordpress/smile-web/
 Version: 6.0.7
-Author: SMiLE Comunicación
+Author: SMiLE Communication
 Author URI: https://www.linkedin.com/in/cesarbla/
 Description: Free theme, SEO optimized. Gain visibility and reach the top positions in search engines quickly. Fully configured and very easy to self-manage with the integration of WordPress Guttemberg blocks editor.
 Requires at least: 6.3

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -9,7 +9,7 @@
 
 ?>
 <section class="no-results not-found">
-<h2 class="display-4"><?php esc_html_e( 'No hay resultados', 'smile-web' ); ?></h2>
+<h2 class="display-4"><?php esc_html_e( 'No results found', 'smile-web' ); ?></h2>
 
 	<div class="page-content">
 		<?php


### PR DESCRIPTION
## Summary
- replace Spanish strings in templates with English text
- update translation template with new English source strings

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint:js` (fails: wp-scripts: not found)
- `npm run lint:scss` (fails: wp-scripts: not found)


------
https://chatgpt.com/codex/tasks/task_e_68beb3000de48330ba0381e2a954d4ac