### PR TITLE
Sanitize dynamic color values

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -9,51 +9,51 @@
  * Outputs inline dynamic CSS based on customizer settings.
  */
 function smile_web_add_dynamic_styles() {
-	$color_text       = get_theme_mod( 'color_text', '#00112b' );
-	$color_link       = get_theme_mod( 'color_link', '#307C03' );
-	$color_link_hover = get_theme_mod( 'color_link_hover', '#306a93' );
-	$color_link_light = get_theme_mod( 'color_link_light', '#4a994f' );
-	$color_1_light    = get_theme_mod( 'color_1_light', '#d2e1ef' );
-	$color_1          = get_theme_mod( 'color_1', '#d2e1ef' );
-	$color_2          = get_theme_mod( 'color_2', '#225274' );
-	$color_2_dark     = get_theme_mod( 'color_2_dark', '#001833' );
-	$bg_light         = get_theme_mod( 'bg_light', '#f6fbf7' );
-	$bg_light2        = get_theme_mod( 'bg_light2', '#f8f9fa' );
-       $footer_bg        = get_theme_mod( 'footer_bg', '#274c77' );
-       $footer_text      = get_theme_mod( 'footer_text', '#FFFEFA' );
-      $footer_link       = get_theme_mod( 'footer_link_color', '#307C03' );
-      $footer_link_hover = get_theme_mod( 'footer_link_hover_color', '#306a93' );
-      $footer_border     = get_theme_mod( 'footer_border_color', '#f6fbf7' );
-       $footer_social_bg   = get_theme_mod( 'footer_social_bg', '#4a994f' );
-       $footer_social_icon = get_theme_mod( 'footer_social_icon', '#FFFFFF' );
-       $color_white      = '#FFFFFF';
-       $border_color     = '#dee2e6';
-       $modal_border     = '#888888';
+	$color_text         = sanitize_hex_color( get_theme_mod( 'color_text', '#00112b' ) );
+	$color_link         = sanitize_hex_color( get_theme_mod( 'color_link', '#307C03' ) );
+	$color_link_hover   = sanitize_hex_color( get_theme_mod( 'color_link_hover', '#306a93' ) );
+	$color_link_light   = sanitize_hex_color( get_theme_mod( 'color_link_light', '#4a994f' ) );
+	$color_1_light      = sanitize_hex_color( get_theme_mod( 'color_1_light', '#d2e1ef' ) );
+	$color_1            = sanitize_hex_color( get_theme_mod( 'color_1', '#d2e1ef' ) );
+	$color_2            = sanitize_hex_color( get_theme_mod( 'color_2', '#225274' ) );
+	$color_2_dark       = sanitize_hex_color( get_theme_mod( 'color_2_dark', '#001833' ) );
+	$bg_light           = sanitize_hex_color( get_theme_mod( 'bg_light', '#f6fbf7' ) );
+	$bg_light2          = sanitize_hex_color( get_theme_mod( 'bg_light2', '#f8f9fa' ) );
+	$footer_bg          = sanitize_hex_color( get_theme_mod( 'footer_bg', '#274c77' ) );
+	$footer_text        = sanitize_hex_color( get_theme_mod( 'footer_text', '#FFFEFA' ) );
+	$footer_link        = sanitize_hex_color( get_theme_mod( 'footer_link_color', '#307C03' ) );
+	$footer_link_hover  = sanitize_hex_color( get_theme_mod( 'footer_link_hover_color', '#306a93' ) );
+	$footer_border      = sanitize_hex_color( get_theme_mod( 'footer_border_color', '#f6fbf7' ) );
+	$footer_social_bg   = sanitize_hex_color( get_theme_mod( 'footer_social_bg', '#4a994f' ) );
+	$footer_social_icon = sanitize_hex_color( get_theme_mod( 'footer_social_icon', '#FFFFFF' ) );
+	$color_white        = sanitize_hex_color( '#FFFFFF' );
+	$border_color       = sanitize_hex_color( '#dee2e6' );
+	$modal_border       = sanitize_hex_color( '#888888' );
 
-	$dynamic_css = "
+	$dynamic_css = '
 		:root {
-			--color-text: {$color_text};
-			--color-link: {$color_link};
-			--color-link-hover: {$color_link_hover};
-			--color-link-light: {$color_link_light};
-			--color-1-light: {$color_1_light};
-			--color-1: {$color_1};
-			--color-2: {$color_2};
-			--color-2-dark: {$color_2_dark};
-			--color-white: {$color_white};
-			--bg-light: {$bg_light};
-			--bg-light2: {$bg_light2};
-                       --footer-bg: {$footer_bg};
-                       --footer-text: {$footer_text};
-                      --footer-link: {$footer_link};
-                      --footer-link-hover: {$footer_link_hover};
-                      --footer-border: {$footer_border};
-                      --footer-social-bg: {$footer_social_bg};
-                      --footer-social-icon: {$footer_social_icon};
-                      --border-color: {$border_color};
-                      --modal-border: {$modal_border};
-              }
-       ";
+			--color-text: ' . esc_attr( $color_text ) . ';
+			--color-link: ' . esc_attr( $color_link ) . ';
+			--color-link-hover: ' . esc_attr( $color_link_hover ) . ';
+			--color-link-light: ' . esc_attr( $color_link_light ) . ';
+			--color-1-light: ' . esc_attr( $color_1_light ) . ';
+			--color-1: ' . esc_attr( $color_1 ) . ';
+			--color-2: ' . esc_attr( $color_2 ) . ';
+			--color-2-dark: ' . esc_attr( $color_2_dark ) . ';
+			--color-white: ' . esc_attr( $color_white ) . ';
+			--bg-light: ' . esc_attr( $bg_light ) . ';
+			--bg-light2: ' . esc_attr( $bg_light2 ) . ';
+			--footer-bg: ' . esc_attr( $footer_bg ) . ';
+			--footer-text: ' . esc_attr( $footer_text ) . ';
+			--footer-link: ' . esc_attr( $footer_link ) . ';
+			--footer-link-hover: ' . esc_attr( $footer_link_hover ) . ';
+			--footer-border: ' . esc_attr( $footer_border ) . ';
+			--footer-social-bg: ' . esc_attr( $footer_social_bg ) . ';
+			--footer-social-icon: ' . esc_attr( $footer_social_icon ) . ';
+			--border-color: ' . esc_attr( $border_color ) . ';
+			--modal-border: ' . esc_attr( $modal_border ) . ';
+		}
+	';
 
 	// Se agrega el CSS en línea al handle 'smile-web-main'.
 	wp_add_inline_style( 'smile-web-main', $dynamic_css );
@@ -64,9 +64,9 @@ add_action( 'wp_enqueue_scripts', 'smile_web_add_dynamic_styles' );
  * Outputs custom CSS stored via the Customizer.
  */
 function smile_v6_custom_css_output() {
-        $custom_css = wp_get_custom_css();
-        if ( ! empty( $custom_css ) ) {
-                echo '<style type="text/css">' . wp_strip_all_tags( $custom_css ) . '</style>';
-        }
+	$custom_css = wp_get_custom_css();
+	if ( ! empty( $custom_css ) ) {
+		echo '<style type="text/css">' . esc_html( wp_strip_all_tags( $custom_css ) ) . '</style>';
+	}
 }
 add_action( 'wp_head', 'smile_v6_custom_css_output' );


### PR DESCRIPTION
## Summary
- sanitize all dynamic color options using `sanitize_hex_color`
- escape color CSS variables with `esc_attr`
- escape custom CSS output with `esc_html`

## Testing
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs -v --standard=WordPress inc/customizer-dynamic-styles.php`
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs --standard=WordPress --report-summary .`

------
https://chatgpt.com/codex/tasks/task_e_68bec813eb2c8330933da10910901f9b