### PR TITLE
Remove top bar social background color variable

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -103,7 +103,6 @@
 }
 
 #topBar .social-links a {
-  background-color: var(--topbar-social-bg);
   color: var(--topbar-social-icon);
 }
 

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -24,7 +24,6 @@ function smile_web_add_dynamic_styles() {
        $topbar_link       = sanitize_hex_color( get_theme_mod( 'topbar_link', '#307C03' ) );
        $topbar_link_hover = sanitize_hex_color( get_theme_mod( 'topbar_link_hover', '#306a93' ) );
        $topbar_social_icon = sanitize_hex_color( get_theme_mod( 'topbar_social_icon', '#001833' ) );
-       $topbar_social_bg   = sanitize_hex_color( get_theme_mod( 'topbar_social_bg', '#f8f9fa' ) );
        $masthead_bg        = sanitize_hex_color( get_theme_mod( 'masthead_bg', '#001833' ) );
        $masthead_text      = sanitize_hex_color( get_theme_mod( 'masthead_text', '#d2e1ef' ) );
        $masthead_link      = sanitize_hex_color( get_theme_mod( 'masthead_link', '#d2e1ef' ) );
@@ -59,7 +58,6 @@ function smile_web_add_dynamic_styles() {
                        --topbar-link: ' . esc_attr( $topbar_link ) . ';
                        --topbar-link-hover: ' . esc_attr( $topbar_link_hover ) . ';
                        --topbar-social-icon: ' . esc_attr( $topbar_social_icon ) . ';
-                       --topbar-social-bg: ' . esc_attr( $topbar_social_bg ) . ';
                        --masthead-bg: ' . esc_attr( $masthead_bg ) . ';
                        --masthead-text: ' . esc_attr( $masthead_text ) . ';
                        --masthead-link: ' . esc_attr( $masthead_link ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -212,15 +212,11 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 				'default' => '#306a93',
 				'label'   => esc_html__( 'Top Bar Link Hover Color', 'smile-web' ),
 			),
-			'topbar_social_icon' => array(
-				'default' => '#001833',
-				'label'   => esc_html__( 'Top Bar Social Icon Color', 'smile-web' ),
-			),
-			'topbar_social_bg'   => array(
-				'default' => '#f8f9fa',
-				'label'   => esc_html__( 'Top Bar Social Background Color', 'smile-web' ),
-			),
-		);
+                        'topbar_social_icon' => array(
+                                'default' => '#001833',
+                                'label'   => esc_html__( 'Top Bar Social Icon Color', 'smile-web' ),
+                        ),
+                );
 
 		// Masthead color controls.
 		$masthead_colors = array(

--- a/style.css
+++ b/style.css
@@ -291,7 +291,6 @@ a:hover {
     margin: 0 8px;
     text-align: center;
     transition: .3s;
-    background-color: var(--topbar-social-bg);
     color: var(--topbar-social-icon);
 }
 


### PR DESCRIPTION
## Summary
- drop `topbar_social_bg` option and variable generation
- clear `background-color` on top bar social links for transparency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:js` *(fails: wp-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bef21fa2e88330807a4c06e6f456b6