### PR TITLE
Style search icon in top bar

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -114,6 +114,10 @@
   fill: var(--topbar-social-icon);
 }
 
+#topBar .buscar svg {
+  fill: var(--topbar-social-icon);
+}
+
 #footer .svg-icon svg {
   fill: var(--footer-social-icon);
 }

--- a/header.php
+++ b/header.php
@@ -62,7 +62,7 @@
 			</div>
 			<div>
 				<a id="myBtn" href="#" class="p-2 buscar" aria-label="<?php esc_attr_e( 'Open search box', 'smile-web' ); ?>" itemprop="url" data-bs-toggle="modal" data-bs-target="#searchModal" rel="nofollow noopener noreferrer">
-					<span title="<?php esc_attr_e( 'Search in web', 'smile-web' ); ?>" class="buscar p-0" aria-hidden="true">
+<span title="<?php esc_attr_e( 'Search in web', 'smile-web' ); ?>" class="buscar svg-icon p-0" aria-hidden="true">
 						<svg width="20" height="20" viewBox="0 0 8 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
 							<g transform="matrix(1,0,0,1,-1111.24,-105.745)">
 								<g transform="matrix(0.0136842,0,0,0.0136842,1111.24,105.745)">

--- a/style.css
+++ b/style.css
@@ -304,6 +304,10 @@ a:hover {
     fill: var(--topbar-social-icon);
 }
 
+#topBar .buscar svg {
+    fill: var(--topbar-social-icon);
+}
+
 .header-scrolled {
     background-color: var(--masthead-scrolled-bg);
     transition: background-color 0.3s ease;


### PR DESCRIPTION
## Summary
- add reusable `svg-icon` class to search span
- style top bar search SVG with `--topbar-social-icon` color

## Testing
- `php -l header.php`
- `npm test` *(fails: Missing script "test")*
- `npm run lint:js` *(fails: wp-scripts: not found; `npm install` failed: node-sass missing distutils)*
- `npx stylelint style.css assets/css/main.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68bef532fd9083309e5c21a6da365649