### PR TITLE
Fix header nav background for scrolled state

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -288,8 +288,8 @@ a:hover {
     height: 25px;
 }
 
-.header-scrolled {
-    background-color: var(--color-1-light);
+.header-scrolled nav {
+    background-color: var(--masthead-scrolled-bg);
     transition: background-color 0.3s ease;
 }
 

--- a/style.css
+++ b/style.css
@@ -308,7 +308,7 @@ a:hover {
     fill: var(--topbar-social-icon);
 }
 
-.header-scrolled {
+.header-scrolled nav {
     background-color: var(--masthead-scrolled-bg);
     transition: background-color 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- apply masthead scrolled background color to navigation when header is scrolled
- update RTL stylesheet to mirror navigation background change

## Testing
- ⚠️ `npm test` *(Missing script: "test")*
- ⚠️ `npm install --no-save --package-lock=false` *(node-sass build failed: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_68bfd3a829c88330b2c0e83a874b2746