### PR TITLE
Refine masthead submenu colors

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -284,3 +284,28 @@
 .whatsapp-background:hover svg {
   color: #e0e0e0;
 }
+
+/* Navigation submenu */
+#nav-menu .sub-menu {
+  background-color: var(--masthead-submenu-bg);
+  color: var(--masthead-submenu-text);
+}
+
+#nav-menu .sub-menu li>a {
+  color: var(--masthead-submenu-text);
+}
+
+#nav-menu .sub-menu li>a:hover {
+  color: var(--masthead-link-hover);
+}
+
+.menu-item-has-children i::after {
+  color: var(--masthead-submenu-text);
+}
+
+@media (min-width: 768px) {
+  #nav-menu .sub-menu {
+    background-color: var(--masthead-submenu-bg);
+    color: var(--masthead-submenu-text);
+  }
+}

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -27,6 +27,7 @@ function smile_web_add_dynamic_styles() {
        $masthead_bg          = sanitize_hex_color( get_theme_mod( 'masthead_bg', '#001833' ) );
        $masthead_submenu_bg   = sanitize_hex_color( get_theme_mod( 'masthead_submenu_bg', '#001833' ) );
        $masthead_submenu_text = sanitize_hex_color( get_theme_mod( 'masthead_submenu_text', '#d2e1ef' ) );
+       $masthead_text         = sanitize_hex_color( get_theme_mod( 'masthead_text', '#d2e1ef' ) );
        $masthead_link         = sanitize_hex_color( get_theme_mod( 'masthead_link', '#d2e1ef' ) );
        $masthead_link_hover   = sanitize_hex_color( get_theme_mod( 'masthead_link_hover', '#306a93' ) );
        $masthead_scrolled_bg  = sanitize_hex_color( get_theme_mod( 'masthead_scrolled_bg', '#d2e1ef' ) );
@@ -62,6 +63,7 @@ function smile_web_add_dynamic_styles() {
                        --masthead-bg: ' . esc_attr( $masthead_bg ) . ';
                        --masthead-submenu-bg: ' . esc_attr( $masthead_submenu_bg ) . ';
                        --masthead-submenu-text: ' . esc_attr( $masthead_submenu_text ) . ';
+                       --masthead-text: ' . esc_attr( $masthead_text ) . ';
                        --masthead-link: ' . esc_attr( $masthead_link ) . ';
                        --masthead-link-hover: ' . esc_attr( $masthead_link_hover ) . ';
                        --masthead-scrolled-bg: ' . esc_attr( $masthead_scrolled_bg ) . ';

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -451,12 +451,15 @@ ul .sub-menu {
     list-style: none;
     position: relative;
     background-color: var(--masthead-submenu-bg);
+    color: var(--masthead-submenu-text);
     border-top: 1px solid var(--masthead-link-hover);
 }
 
 @media (min-width: 768px) {
     #nav-menu .sub-menu {
         border-top: none;
+        background-color: var(--masthead-submenu-bg);
+        color: var(--masthead-submenu-text);
     }
 }
 
@@ -560,6 +563,7 @@ ul .sub-menu {
         min-width: 150px;
         max-width: 250px;
         background-color: var(--masthead-submenu-bg);
+        color: var(--masthead-submenu-text);
         display: block !important;
         max-height: none !important;
     }

--- a/style.css
+++ b/style.css
@@ -320,7 +320,7 @@ a:hover {
 #masthead {
     transition: all 0.5s;
     background-color: var(--masthead-bg);
-    color: var(--masthead-submenu-text);
+    color: var(--masthead-text);
 }
 
 #masthead a {
@@ -341,7 +341,7 @@ nav {
     transition: all 0.5s;
     padding: 15px 0;
     background-color: var(--masthead-bg);
-    color: var(--masthead-submenu-text);
+    color: var(--masthead-text);
 }
 
 .header-scrolled .header-scrolled-visible p,
@@ -483,12 +483,15 @@ ul .sub-menu {
     list-style: none;
     position: relative;
     background-color: var(--masthead-submenu-bg);
+    color: var(--masthead-submenu-text);
     border-top: 1px solid var(--masthead-link-hover);
 }
 
 @media (min-width: 768px) {
     #nav-menu .sub-menu {
         border-top: none;
+        background-color: var(--masthead-submenu-bg);
+        color: var(--masthead-submenu-text);
     }
 }
 
@@ -592,6 +595,7 @@ ul .sub-menu {
         min-width: 150px;
         max-width: 250px;
         background-color: var(--masthead-submenu-bg);
+        color: var(--masthead-submenu-text);
         display: block !important;
         max-height: none !important;
     }


### PR DESCRIPTION
## Summary
- tie masthead submenu colors and text to CSS variables
- introduce `--masthead-text` and apply it to masthead and nav
- sync navigation submenu rules in RTL and compiled CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:scss` *(fails: wp-scripts: not found)*
- `npm install` *(fails: node-sass build error: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_68bfe3ee675883308bef8115501ad447