### PR TITLE
Use masthead color variables for mobile menu bars

### DIFF
--- a/inc/enqueues.php
+++ b/inc/enqueues.php
@@ -122,9 +122,14 @@ function smile_v6_enqueue_scripts() {
 .bar3 {
     width: 35px;
     height: 5px;
-    background-color: var(--color-link-hover);
+    background-color: var(--masthead-link);
     margin: 6px 0;
     transition: 0.4s;
+}
+#nav-toggle:hover .bar1,
+#nav-toggle:hover .bar2,
+#nav-toggle:hover .bar3 {
+    background-color: var(--masthead-link-hover);
 }
 .menu-bar-change .bar1 {
     -webkit-transform: rotate(-45deg) translate(-9px, 6px);


### PR DESCRIPTION
## Summary
- Align mobile menu bar colors with masthead variables
- Add hover styling for menu bars using `--masthead-link-hover`

## Testing
- `npm run compile:css` *(fails: node-sass/stylelint not found)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bfe781652883308fb19c728d3591c2