### PR TITLE
Remove obsolete Color 1 references

### DIFF
--- a/assets/css/editor-style.css
+++ b/assets/css/editor-style.css
@@ -49,7 +49,7 @@ button:hover, .button:hover {
 }
 
 blockquote {
-    border-left: 5px solid var(--color-1);
+    border-left: 5px solid var(--accent-primary);
     padding-left: 20px;
     font-style: italic;
 }

--- a/inc/enqueues.php
+++ b/inc/enqueues.php
@@ -161,7 +161,7 @@ function smile_v6_enqueue_scripts() {
 	if ( is_front_page() ) {
 		$dynamic_css .= '
 #intro {
-    background-color: var(--color-2-dark);
+    background-color: var(--accent-secondary-dark);
     color: var(--color-white);
     position: relative;
     z-index: 0;
@@ -170,7 +170,7 @@ function smile_v6_enqueue_scripts() {
 }
 #intro h1 {
     margin: 0;
-    color: var(--color-1-light);
+    color: var(--accent-primary-light);
     width: 100%;
 }
 #intro .row {
@@ -223,7 +223,7 @@ function smile_v6_enqueue_scripts() {
         height: 100%;
         margin: 0;
         overflow: hidden;
-        background-color: var(--color-2-dark);
+        background-color: var(--accent-secondary-dark);
     }
     #intro-carousel img {
         width: 100%;
@@ -246,15 +246,15 @@ function smile_v6_enqueue_scripts() {
 	} elseif ( is_page() ) {
 		$dynamic_css .= '
 #intro {
-    background-color: var(--color-2-dark);
+        background-color: var(--accent-secondary-dark);
     color: var(--color-white);
     position: relative;
     z-index: 0;
     margin-bottom: -10px;
     min-height: 300px;
 }
-#intro h1 {
-    color: var(--color-1-light);
+    #intro h1 {
+    color: var(--accent-primary-light);
     width: 100%;
 }
 .entry-header {
@@ -297,7 +297,7 @@ function smile_v6_enqueue_scripts() {
         height: 100%;
         margin: 0;
         overflow: hidden;
-        background-color: var(--color-2-dark);
+        background-color: var(--accent-secondary-dark);
     }
     #intro-carousel img {
         width: 100%;
@@ -320,14 +320,14 @@ function smile_v6_enqueue_scripts() {
 	} else {
 		$dynamic_css .= '
 #intro {
-    background-color: var(--color-2-dark);
+    background-color: var(--accent-secondary-dark);
     color: var(--color-white);
     position: relative;
     z-index: 0;
     margin-bottom: -10px;
 }
-#intro h1 {
-    color: var(--color-1-light);
+    #intro h1 {
+    color: var(--accent-primary-light);
     width: 100%;
 }
 .entry-header {


### PR DESCRIPTION
## Summary
- Replace outdated `--color-1-light` and `--color-2-dark` references with `--accent-primary-light` and `--accent-secondary-dark`
- Use `--accent-primary` for editor blockquote border

## Testing
- `php -l inc/enqueues.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c003cd88908330a1dd61bc2bea383c