### PR TITLE
feat: add customizable accents

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -14,7 +14,9 @@ function smile_web_add_dynamic_styles() {
 		$color_link_hover         = sanitize_hex_color( get_theme_mod( 'color_link_hover', '#306a93' ) );
 		$color_link_light         = sanitize_hex_color( get_theme_mod( 'color_link_light', '#4a994f' ) );
 		$color_muted              = sanitize_hex_color( get_theme_mod( 'color_muted', '#6c757d' ) );
-		$color_warning            = sanitize_hex_color( get_theme_mod( 'color_warning', '#ffc107' ) );
+               $color_warning            = sanitize_hex_color( get_theme_mod( 'color_warning', '#ffc107' ) );
+               $cta_bg                   = sanitize_hex_color( get_theme_mod( 'cta_bg', '#ffc107' ) );
+               $breadcrumb_separator     = sanitize_text_field( get_theme_mod( 'breadcrumb_separator', '/' ) );
 		$accent_primary_light     = sanitize_hex_color( get_theme_mod( 'accent-primary-light', '#d2e1ef' ) );
 		$accent_primary           = sanitize_hex_color( get_theme_mod( 'accent-primary', '#d2e1ef' ) );
 		$accent_secondary         = sanitize_hex_color( get_theme_mod( 'accent-secondary', '#225274' ) );
@@ -52,7 +54,9 @@ function smile_web_add_dynamic_styles() {
                         --color-link-hover: ' . esc_attr( $color_link_hover ) . ';
                         --color-link-light: ' . esc_attr( $color_link_light ) . '; 
                        --color-muted: ' . esc_attr( $color_muted ) . '; 
-                       --color-warning: ' . esc_attr( $color_warning ) . '; 
+                       --color-warning: ' . esc_attr( $color_warning ) . ';
+                       --cta-bg: ' . esc_attr( $cta_bg ) . ';
+                       --breadcrumb-separator: "' . esc_attr( $breadcrumb_separator ) . '";
                        --accent-primary-light: ' . esc_attr( $accent_primary_light ) . ';
                        --accent-primary: ' . esc_attr( $accent_primary ) . ';
                        --accent-secondary: ' . esc_attr( $accent_secondary ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -78,12 +78,12 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 	);
 
 	// Array with general settings.
-	$settings = array(
-		'top_bar_email'      => array(
-			'label'   => esc_html__( 'Top Bar Email', 'smile-web' ),
-			'type'    => 'email',
-			'default' => '',
-		),
+        $settings = array(
+                'top_bar_email'      => array(
+                        'label'   => esc_html__( 'Top Bar Email', 'smile-web' ),
+                        'type'    => 'email',
+                        'default' => '',
+                ),
 		'top_bar_telephone'  => array(
 			'label'   => esc_html__( 'Top Bar Telephone', 'smile-web' ),
 			'type'    => 'text',
@@ -119,12 +119,17 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 			'type'    => 'number',
 			'default' => 0,
 		),
-		'footer_logo'        => array(
-			'label'   => esc_html__( 'Footer Logo', 'smile-web' ),
-			'type'    => 'image',
-			'default' => '',
-		),
-	);
+                'footer_logo'        => array(
+                        'label'   => esc_html__( 'Footer Logo', 'smile-web' ),
+                        'type'    => 'image',
+                        'default' => '',
+                ),
+               'breadcrumb_separator' => array(
+                       'label'   => esc_html__( 'Breadcrumb Separator', 'smile-web' ),
+                       'type'    => 'text',
+                       'default' => '/',
+               ),
+        );
 
 	// Create settings and controls for general settings.
 	foreach ( $settings as $id => $args ) {
@@ -150,12 +155,13 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 		);
 	}
 
-		// Global color controls.
-		$global_colors = array(
-			'color_text'            => array(
-				'default' => '#00112b',
-				'label'   => esc_html__( 'Text Color', 'smile-web' ),
-			),
+               // Global color controls.
+               // Ensure chosen colors maintain a 4.5:1 contrast ratio for accessibility.
+               $global_colors = array(
+                        'color_text'            => array(
+                                'default' => '#00112b',
+                                'label'   => esc_html__( 'Text Color', 'smile-web' ),
+                        ),
 			'color_link'            => array(
 				'default' => '#307C03',
 				'label'   => esc_html__( 'Link Color', 'smile-web' ),
@@ -172,14 +178,18 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 				'default' => '#6c757d',
 				'label'   => esc_html__( 'Muted Color', 'smile-web' ),
 			),
-			'color_warning'         => array(
-				'default' => '#ffc107',
-				'label'   => esc_html__( 'Warning Color', 'smile-web' ),
-			),
-			'accent-primary-light'  => array(
-				'default' => '#d2e1ef',
-				'label'   => esc_html__( 'Primary Accent Color Light', 'smile-web' ),
-			),
+                        'color_warning'         => array(
+                                'default' => '#ffc107',
+                                'label'   => esc_html__( 'Warning Color', 'smile-web' ),
+                        ),
+                       'cta_bg'                => array(
+                               'default' => '#ffc107',
+                               'label'   => esc_html__( 'CTA Background Color', 'smile-web' ),
+                       ),
+                        'accent-primary-light'  => array(
+                                'default' => '#d2e1ef',
+                                'label'   => esc_html__( 'Primary Accent Color Light', 'smile-web' ),
+                        ),
 			'accent-primary'        => array(
 				'default' => '#d2e1ef',
 				'label'   => esc_html__( 'Primary Accent Color', 'smile-web' ),

--- a/inc/enqueues.php
+++ b/inc/enqueues.php
@@ -268,7 +268,7 @@ function smile_v6_enqueue_scripts() {
     line-height: 2em;
 }
 #breadcrumbs li:not(:first-child)::before {
-    content: "/";
+    content: var(--breadcrumb-separator);
     float: left;
     padding-right: 0.5rem;
     color: var(--color-muted);
@@ -341,7 +341,7 @@ function smile_v6_enqueue_scripts() {
     line-height: 2em;
 }
 #breadcrumbs li:not(:first-child)::before {
-    content: "/";
+    content: var(--breadcrumb-separator);
     float: left;
     padding-right: 0.5rem;
     color: var(--color-muted);

--- a/page-sidebar.php
+++ b/page-sidebar.php
@@ -144,7 +144,7 @@ get_header();
                                                         ?>
                                                         <img class="img-fluid" src="<?php echo esc_url( $thumb_url ); ?>" alt="<?php echo esc_attr( $thumb_alt ); ?>">
                                                 </a>
-                                                <figcaption id="post-<?php the_ID(); ?>" class="p-4 text-white">
+                                                <figcaption id="post-<?php the_ID(); ?>" class="p-4" style="color: var(--color-white);">
                                                         <h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
                                                         <p><?php the_excerpt(); ?></p>
                                                         <hr>

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,10 @@ Full Font Awesome Free license: https://fontawesome.com/license/free.
 2. Click Upload Theme and Choose File, then select the theme's .zip file. Click Install Now.
 3. Click Activate to use your new theme right away.
 
+== Accessibility ==
+
+Color selections should provide at least a 4.5:1 contrast ratio between text and background to meet WCAG 2.1 AA requirements.
+
 == Credits ==
 
 * Based on Underscores https://underscores.me/, (C) 2012-2020 Automattic, Inc., [GPLv2 or later](https://www.gnu.org/licenses/gpl-2.0.html)

--- a/single.php
+++ b/single.php
@@ -59,14 +59,14 @@ get_header();
 						<span> |
 							<?php
 							// SVG icon for comments.
-							$comment_svg = '
-							<svg style="fill: #fff; width: 20px; height: 20px; position: relative; top: 5px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                                                        $comment_svg = '
+                                                        <svg style="fill: var(--color-white); width: 20px; height: 20px; position: relative; top: 5px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
 								<path d="M256 32C114.6 32 0 125.1 0 240c0 49.5 21.4 94.9 57.1 131.5-12.2 50.7-54.3 95.3-55 95.9C0 470.8-.5 471.3.3 472.6c.9 1.3 2.1 1.4 3.2 1.4 66.3 0 117.1-31.4 139.8-46.7 33.1 9.4 69 14.7 112.7 14.7 141.4 0 256-93.1 256-208S397.4 32 256 32z"/>
 							</svg>';
 							echo '<span class="svg-icon">' . wp_kses_post( $comment_svg ) . '</span>';
 							esc_html_e( 'Comments', 'smile-web' );
 							?>
-							<a href="#comments" class='text-white'><?php echo esc_html( get_comments_number() ); ?></a>
+                                                        <a href="#comments" style="color: var(--color-white);"><?php echo esc_html( get_comments_number() ); ?></a>
 						</span>
 					<?php endif; ?>
 				<?php endif; ?>

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -562,7 +562,7 @@ ul .sub-menu {
 
     #nav-menu a:hover {
         color: var(--masthead-link-hover);
-        background-color: var(--color-warning);
+        background-color: var(--cta-bg);
     }
 
     .menu-item-has-children {
@@ -1088,7 +1088,8 @@ main ol li::marker {
 }
 
 .bg-cta {
-    background: var(--color-warning);
+    /* Ensure CTA background maintains adequate contrast */
+    background: var(--cta-bg);
 }
 
 .bg-footer {

--- a/style.css
+++ b/style.css
@@ -562,7 +562,7 @@ ul .sub-menu {
 
     #nav-menu a:hover {
         color: var(--masthead-link-hover);
-        background-color: var(--color-warning);
+        background-color: var(--cta-bg);
     }
 
     .menu-item-has-children {
@@ -1088,7 +1088,8 @@ main ol li::marker {
 }
 
 .bg-cta {
-    background: var(--color-warning);
+    /* Ensure CTA background maintains adequate contrast */
+    background: var(--cta-bg);
 }
 
 .bg-footer {


### PR DESCRIPTION
## Summary
- add Customizer options for breadcrumb separator and CTA background
- replace fixed color codes with CSS variables
- document color contrast expectations

## Testing
- `npm run lint:scss` *(fails: wp-scripts not found)*
- `npm run lint:js` *(fails: wp-scripts not found)*
- `npx @wordpress/theme-check .` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0060e7b0c8330b31b692c990f48dc