### PR TITLE
feat: add customizable heading, lead, and border colors

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -12,11 +12,13 @@ function smile_web_add_dynamic_styles() {
 	$color_text                   = sanitize_hex_color( get_theme_mod( 'color_text', '#00112b' ) );
 	$color_link                   = sanitize_hex_color( get_theme_mod( 'color_link', '#307C03' ) );
 		$color_link_hover         = sanitize_hex_color( get_theme_mod( 'color_link_hover', '#306a93' ) );
-		$color_link_light         = sanitize_hex_color( get_theme_mod( 'color_link_light', '#4a994f' ) );
-		$color_muted              = sanitize_hex_color( get_theme_mod( 'color_muted', '#6c757d' ) );
-               $color_warning            = sanitize_hex_color( get_theme_mod( 'color_warning', '#ffc107' ) );
-               $cta_bg                   = sanitize_hex_color( get_theme_mod( 'cta_bg', '#ffc107' ) );
-               $breadcrumb_separator     = sanitize_text_field( get_theme_mod( 'breadcrumb_separator', '/' ) );
+$color_link_light         = sanitize_hex_color( get_theme_mod( 'color_link_light', '#4a994f' ) );
+$color_muted              = sanitize_hex_color( get_theme_mod( 'color_muted', '#6c757d' ) );
+$color_warning            = sanitize_hex_color( get_theme_mod( 'color_warning', '#ffc107' ) );
+$cta_bg                   = sanitize_hex_color( get_theme_mod( 'cta_bg', '#ffc107' ) );
+$heading_color            = sanitize_hex_color( get_theme_mod( 'heading_color', '#306a93' ) );
+$lead_color               = sanitize_hex_color( get_theme_mod( 'lead_color', '#306a93' ) );
+$breadcrumb_separator     = sanitize_text_field( get_theme_mod( 'breadcrumb_separator', '/' ) );
 		$accent_primary_light     = sanitize_hex_color( get_theme_mod( 'accent-primary-light', '#d2e1ef' ) );
 		$accent_primary           = sanitize_hex_color( get_theme_mod( 'accent-primary', '#d2e1ef' ) );
 		$accent_secondary         = sanitize_hex_color( get_theme_mod( 'accent-secondary', '#225274' ) );
@@ -43,20 +45,22 @@ function smile_web_add_dynamic_styles() {
 		$footer_social_bg         = sanitize_hex_color( get_theme_mod( 'footer_social_bg', '#4a994f' ) );
 		$footer_social_icon       = sanitize_hex_color( get_theme_mod( 'footer_social_icon', '#FFFFFF' ) );
 		$footer_social_icon_hover = sanitize_hex_color( get_theme_mod( 'footer_social_icon_hover', '#4a994f' ) );
-	$color_white                  = sanitize_hex_color( '#FFFFFF' );
-	$border_color                 = sanitize_hex_color( '#dee2e6' );
-	$modal_border                 = sanitize_hex_color( '#888888' );
+$color_white                  = sanitize_hex_color( '#FFFFFF' );
+$border_color                 = sanitize_hex_color( get_theme_mod( 'border_color', '#dee2e6' ) );
+$modal_border                 = sanitize_hex_color( '#888888' );
 
 	$dynamic_css = '
 		:root {
 			--color-text: ' . esc_attr( $color_text ) . ';
 			--color-link: ' . esc_attr( $color_link ) . ';
-                        --color-link-hover: ' . esc_attr( $color_link_hover ) . ';
-                        --color-link-light: ' . esc_attr( $color_link_light ) . '; 
-                       --color-muted: ' . esc_attr( $color_muted ) . '; 
-                       --color-warning: ' . esc_attr( $color_warning ) . ';
-                       --cta-bg: ' . esc_attr( $cta_bg ) . ';
-                       --breadcrumb-separator: "' . esc_attr( $breadcrumb_separator ) . '";
+--color-link-hover: ' . esc_attr( $color_link_hover ) . ';
+--color-link-light: ' . esc_attr( $color_link_light ) . ';
+   --color-muted: ' . esc_attr( $color_muted ) . ';
+   --color-warning: ' . esc_attr( $color_warning ) . ';
+   --cta-bg: ' . esc_attr( $cta_bg ) . ';
+   --heading-color: ' . esc_attr( $heading_color ) . ';
+   --lead-color: ' . esc_attr( $lead_color ) . ';
+   --breadcrumb-separator: "' . esc_attr( $breadcrumb_separator ) . '";
                        --accent-primary-light: ' . esc_attr( $accent_primary_light ) . ';
                        --accent-primary: ' . esc_attr( $accent_primary ) . ';
                        --accent-secondary: ' . esc_attr( $accent_secondary ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -206,11 +206,23 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 				'default' => '#edf7ef',
 				'label'   => esc_html__( 'Primary Background Color', 'smile-web' ),
 			),
-			'bg_light2'             => array(
-				'default' => '#f8f9fa',
-				'label'   => esc_html__( 'Secondary Background Color', 'smile-web' ),
-			),
-		);
+'bg_light2'             => array(
+'default' => '#f8f9fa',
+'label'   => esc_html__( 'Secondary Background Color', 'smile-web' ),
+),
+'heading_color'        => array(
+'default' => '#306a93',
+'label'   => esc_html__( 'Heading Color', 'smile-web' ),
+),
+'lead_color'           => array(
+'default' => '#306a93',
+'label'   => esc_html__( 'Lead Color', 'smile-web' ),
+),
+'border_color'         => array(
+'default' => '#dee2e6',
+'label'   => esc_html__( 'Border Color', 'smile-web' ),
+),
+);
 
 		// Top bar color controls.
 		$topbar_colors = array(

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -127,7 +127,7 @@ h1,
 h2,
 .h2 {
     line-height: 1.1em;
-    color: var(--color-link-hover);
+    color: var(--heading-color);
     font-family: var(--font-family-bold);
     padding-top: 0;
     margin: 0;
@@ -1036,12 +1036,12 @@ main ol li::marker {
 }
 
 .border {
-    border: 1px solid var(--color-link-hover) !important;
+    border: 1px solid var(--border-color) !important;
 }
 
 .lead {
     font-weight: 200;
-    color: var(--color-link-hover);
+    color: var(--lead-color);
     font-size: 22px;
     line-height: 1.2em;
     margin-bottom: 30px;

--- a/style.css
+++ b/style.css
@@ -127,7 +127,7 @@ h1,
 h2,
 .h2 {
     line-height: 1.1em;
-    color: var(--color-link-hover);
+    color: var(--heading-color);
     font-family: var(--font-family-bold);
     padding-top: 0;
     margin: 0;
@@ -1036,12 +1036,12 @@ main ol li::marker {
 }
 
 .border {
-    border: 1px solid var(--color-link-hover) !important;
+    border: 1px solid var(--border-color) !important;
 }
 
 .lead {
     font-weight: 200;
-    color: var(--color-link-hover);
+    color: var(--lead-color);
     font-size: 22px;
     line-height: 1.2em;
     margin-bottom: 30px;


### PR DESCRIPTION
## Summary
- add Customizer settings for heading, lead, and border colors
- expose matching CSS variables in dynamic styles
- use new variables for heading, lead text, and border styles

## Testing
- `php -l inc/customizer-options.php`
- `php -l inc/customizer-dynamic-styles.php`
- `npm run compile:css` *(fails: node-sass not found)*
- `npm run compile:rtl` *(fails: rtlcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c02fe1fac4833082f898e98350e327