### PR TITLE
Document Link Color Light bullet usage

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -52,8 +52,9 @@ function smile_web_add_dynamic_styles() {
 			--color-text: ' . esc_attr( $color_text ) . ';
 			--color-link: ' . esc_attr( $color_link ) . ';
                         --color-link-hover: ' . esc_attr( $color_link_hover ) . ';
-                        --color-link-light: ' . esc_attr( $color_link_light ) . '; /* Also controls unordered list bullets */
-                       --color-muted: ' . esc_attr( $color_muted ) . '; 
+                        /* Link Color Light also sets unordered list bullet color */
+                        --color-link-light: ' . esc_attr( $color_link_light ) . ';
+                       --color-muted: ' . esc_attr( $color_muted ) . ';
                        --color-warning: ' . esc_attr( $color_warning ) . ';
                        --cta-bg: ' . esc_attr( $cta_bg ) . ';
                        --breadcrumb-separator: "' . esc_attr( $breadcrumb_separator ) . '";

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -52,7 +52,7 @@ function smile_web_add_dynamic_styles() {
 			--color-text: ' . esc_attr( $color_text ) . ';
 			--color-link: ' . esc_attr( $color_link ) . ';
                         --color-link-hover: ' . esc_attr( $color_link_hover ) . ';
-                        /* Link Color Light also sets unordered list bullet color */
+                        /* Link color for dark backgrounds; also colors list bullets */
                         --color-link-light: ' . esc_attr( $color_link_light ) . ';
                        --color-muted: ' . esc_attr( $color_muted ) . ';
                        --color-warning: ' . esc_attr( $color_warning ) . ';

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -52,7 +52,7 @@ function smile_web_add_dynamic_styles() {
 			--color-text: ' . esc_attr( $color_text ) . ';
 			--color-link: ' . esc_attr( $color_link ) . ';
                         --color-link-hover: ' . esc_attr( $color_link_hover ) . ';
-                        --color-link-light: ' . esc_attr( $color_link_light ) . '; 
+                        --color-link-light: ' . esc_attr( $color_link_light ) . '; /* Also controls unordered list bullets */
                        --color-muted: ' . esc_attr( $color_muted ) . '; 
                        --color-warning: ' . esc_attr( $color_warning ) . ';
                        --cta-bg: ' . esc_attr( $cta_bg ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -170,10 +170,10 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 				'default' => '#306a93',
 				'label'   => esc_html__( 'Link Color Hover', 'smile-web' ),
 			),
-                        'color_link_light'      => array(
-                                'default'     => '#4a994f',
-                                'label'       => esc_html__( 'Link Color Light', 'smile-web' ),
-                                'description' => esc_html__( 'Also sets unordered list bullet color.', 'smile-web' ),
+                       'color_link_light'      => array(
+                                'default' => '#4a994f',
+                                'label'   => esc_html__( 'Link Color Light', 'smile-web' ),
+                                'description' => esc_html__( 'Also colors unordered list bullets', 'smile-web' ),
                         ),
 			'color_muted'           => array(
 				'default' => '#6c757d',
@@ -310,17 +310,21 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 								'sanitize_callback' => 'sanitize_hex_color',
 							)
 						);
-						$wp_customize->add_control(
-							new WP_Customize_Color_Control(
-								$wp_customize,
-								$id,
-								array(
-									'label'    => $args['label'],
-									'section'  => 'custom_theme_global_colors',
-									'settings' => $id,
-								)
-							)
-						);
+                                                $control_args = array(
+                                                        'label'    => $args['label'],
+                                                        'section'  => 'custom_theme_global_colors',
+                                                        'settings' => $id,
+                                                );
+                                                if ( isset( $args['description'] ) ) {
+                                                        $control_args['description'] = $args['description'];
+                                                }
+                                                $wp_customize->add_control(
+                                                        new WP_Customize_Color_Control(
+                                                                $wp_customize,
+                                                                $id,
+                                                                $control_args
+                                                        )
+                                                );
 				}
 
 				// Create settings and controls for top bar colors.

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -170,10 +170,11 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 				'default' => '#306a93',
 				'label'   => esc_html__( 'Link Color Hover', 'smile-web' ),
 			),
-			'color_link_light'      => array(
-				'default' => '#4a994f',
-				'label'   => esc_html__( 'Link Color Light', 'smile-web' ),
-			),
+                        'color_link_light'      => array(
+                                'default'     => '#4a994f',
+                                'label'       => esc_html__( 'Link Color Light', 'smile-web' ),
+                                'description' => esc_html__( 'Also controls the color of unordered list bullets.', 'smile-web' ),
+                        ),
 			'color_muted'           => array(
 				'default' => '#6c757d',
 				'label'   => esc_html__( 'Muted Color', 'smile-web' ),

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -173,7 +173,7 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
                         'color_link_light'      => array(
                                 'default'     => '#4a994f',
                                 'label'       => esc_html__( 'Link Color Light', 'smile-web' ),
-                                'description' => esc_html__( 'Also controls the color of unordered list bullets.', 'smile-web' ),
+                                'description' => esc_html__( 'Also sets unordered list bullet color.', 'smile-web' ),
                         ),
 			'color_muted'           => array(
 				'default' => '#6c757d',

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -982,7 +982,8 @@ hr {
     background-color: var(--accent-primary-light);
 }
 
-/* c# 4.3 - LIST BULLETS */
+/* c# 4.3 - LIST BULLETS
+   Bullets pull from --color-link-light for contrast on dark backgrounds */
 main article li,
 main section li {
     padding-right: 1em;
@@ -1002,8 +1003,8 @@ main li {
 
 main section ul li::before,
 main article ul li::before {
-    /* list bullets draw from the light link color */
     content: "• ";
+    /* use light link color to match links */
     color: var(--color-link-light);
     font-size: 3em;
     position: relative;
@@ -1099,11 +1100,12 @@ main ol li::marker {
 }
 
 .bg-footer a {
+    /* default to light link color for dark footer */
     color: var(--footer-link, var(--color-link-light));
 }
 
 .bg-footer a:hover {
-    color: var(--footer-link-hover, var(--color-link-light));
+    color: var(--footer-link-hover, var(--color-link-hover));
 }
 
 .bg-dark {
@@ -1122,7 +1124,6 @@ main ol li::marker {
 }
 
 .bg-dark a {
-    /* use light link color on dark backgrounds */
     color: var(--color-link-light);
 }
 
@@ -1473,7 +1474,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-links a {
-    color: var(--footer-link, var(--color-link-light));
+    color: var(--footer-link);
 }
 
 #footer .footer-top .footer-contact,
@@ -1496,7 +1497,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-links a:hover {
-    color: var(--footer-link-hover, var(--color-link-light))
+    color: var(--footer-link-hover)
 }
 
 #footer .footer-top .footer-contact p {
@@ -1559,12 +1560,11 @@ footer h3 {
 
 #menu-legal-menu a {
     text-decoration: none;
-    color: var(--footer-link, var(--color-link-light));
+    color: var(--footer-link);
 }
 
 #menu-legal-menu a:hover {
     text-decoration: underline;
-    color: var(--footer-link-hover, var(--color-link-light));
 }
 
 /* ------------------------------------

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1002,7 +1002,7 @@ main li {
 
 main section ul li::before,
 main article ul li::before {
-    /* Bullet color controlled by Link Color Light */
+    /* list bullets draw from the light link color */
     content: "• ";
     color: var(--color-link-light);
     font-size: 3em;
@@ -1098,7 +1098,6 @@ main ol li::marker {
     color: var(--footer-text);
 }
 
-/* Default to light link color on footer background */
 .bg-footer a {
     color: var(--footer-link, var(--color-link-light));
 }
@@ -1122,8 +1121,8 @@ main ol li::marker {
     color: var(--color-white);
 }
 
-/* Use light link color on dark backgrounds */
 .bg-dark a {
+    /* use light link color on dark backgrounds */
     color: var(--color-link-light);
 }
 
@@ -1474,7 +1473,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-links a {
-    color: var(--footer-link);
+    color: var(--footer-link, var(--color-link-light));
 }
 
 #footer .footer-top .footer-contact,
@@ -1497,7 +1496,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-links a:hover {
-    color: var(--footer-link-hover)
+    color: var(--footer-link-hover, var(--color-link-light))
 }
 
 #footer .footer-top .footer-contact p {
@@ -1560,11 +1559,12 @@ footer h3 {
 
 #menu-legal-menu a {
     text-decoration: none;
-    color: var(--footer-link);
+    color: var(--footer-link, var(--color-link-light));
 }
 
 #menu-legal-menu a:hover {
     text-decoration: underline;
+    color: var(--footer-link-hover, var(--color-link-light));
 }
 
 /* ------------------------------------

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1002,6 +1002,7 @@ main li {
 
 main section ul li::before,
 main article ul li::before {
+    /* Bullet color controlled by Link Color Light */
     content: "• ";
     color: var(--color-link-light);
     font-size: 3em;
@@ -1097,12 +1098,13 @@ main ol li::marker {
     color: var(--footer-text);
 }
 
+/* Default to light link color on footer background */
 .bg-footer a {
-    color: var(--footer-link, var(--color-link));
+    color: var(--footer-link, var(--color-link-light));
 }
 
 .bg-footer a:hover {
-    color: var(--footer-link-hover, var(--color-link-hover));
+    color: var(--footer-link-hover, var(--color-link-light));
 }
 
 .bg-dark {
@@ -1120,6 +1122,7 @@ main ol li::marker {
     color: var(--color-white);
 }
 
+/* Use light link color on dark backgrounds */
 .bg-dark a {
     color: var(--color-link-light);
 }

--- a/style.css
+++ b/style.css
@@ -982,7 +982,8 @@ hr {
     background-color: var(--accent-primary-light);
 }
 
-/* c# 4.3 - LIST BULLETS */
+/* c# 4.3 - LIST BULLETS
+   Bullets pull from --color-link-light for contrast on dark backgrounds */
 main article li,
 main section li {
     padding-left: 1em;
@@ -1002,8 +1003,8 @@ main li {
 
 main section ul li::before,
 main article ul li::before {
-    /* list bullets draw from the light link color */
     content: "• ";
+    /* use light link color to match links */
     color: var(--color-link-light);
     font-size: 3em;
     position: relative;
@@ -1099,11 +1100,12 @@ main ol li::marker {
 }
 
 .bg-footer a {
+    /* default to light link color for dark footer */
     color: var(--footer-link, var(--color-link-light));
 }
 
 .bg-footer a:hover {
-    color: var(--footer-link-hover, var(--color-link-light));
+    color: var(--footer-link-hover, var(--color-link-hover));
 }
 
 .bg-dark {
@@ -1122,7 +1124,6 @@ main ol li::marker {
 }
 
 .bg-dark a {
-    /* use light link color on dark backgrounds */
     color: var(--color-link-light);
 }
 
@@ -1473,7 +1474,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-links a {
-    color: var(--footer-link, var(--color-link-light));
+    color: var(--footer-link);
 }
 
 #footer .footer-top .footer-contact,
@@ -1496,7 +1497,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-links a:hover {
-    color: var(--footer-link-hover, var(--color-link-light))
+    color: var(--footer-link-hover)
 }
 
 #footer .footer-top .footer-contact p {
@@ -1559,12 +1560,11 @@ footer h3 {
 
 #menu-legal-menu a {
     text-decoration: none;
-    color: var(--footer-link, var(--color-link-light));
+    color: var(--footer-link);
 }
 
 #menu-legal-menu a:hover {
     text-decoration: underline;
-    color: var(--footer-link-hover, var(--color-link-light));
 }
 
 /* ------------------------------------

--- a/style.css
+++ b/style.css
@@ -1002,7 +1002,7 @@ main li {
 
 main section ul li::before,
 main article ul li::before {
-    /* Bullet color controlled by Link Color Light */
+    /* list bullets draw from the light link color */
     content: "• ";
     color: var(--color-link-light);
     font-size: 3em;
@@ -1098,7 +1098,6 @@ main ol li::marker {
     color: var(--footer-text);
 }
 
-/* Default to light link color on footer background */
 .bg-footer a {
     color: var(--footer-link, var(--color-link-light));
 }
@@ -1122,8 +1121,8 @@ main ol li::marker {
     color: var(--color-white);
 }
 
-/* Use light link color on dark backgrounds */
 .bg-dark a {
+    /* use light link color on dark backgrounds */
     color: var(--color-link-light);
 }
 
@@ -1474,7 +1473,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-links a {
-    color: var(--footer-link);
+    color: var(--footer-link, var(--color-link-light));
 }
 
 #footer .footer-top .footer-contact,
@@ -1497,7 +1496,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-links a:hover {
-    color: var(--footer-link-hover)
+    color: var(--footer-link-hover, var(--color-link-light))
 }
 
 #footer .footer-top .footer-contact p {
@@ -1560,11 +1559,12 @@ footer h3 {
 
 #menu-legal-menu a {
     text-decoration: none;
-    color: var(--footer-link);
+    color: var(--footer-link, var(--color-link-light));
 }
 
 #menu-legal-menu a:hover {
     text-decoration: underline;
+    color: var(--footer-link-hover, var(--color-link-light));
 }
 
 /* ------------------------------------

--- a/style.css
+++ b/style.css
@@ -1002,6 +1002,7 @@ main li {
 
 main section ul li::before,
 main article ul li::before {
+    /* Bullet color controlled by Link Color Light */
     content: "• ";
     color: var(--color-link-light);
     font-size: 3em;
@@ -1097,12 +1098,13 @@ main ol li::marker {
     color: var(--footer-text);
 }
 
+/* Default to light link color on footer background */
 .bg-footer a {
-    color: var(--footer-link, var(--color-link));
+    color: var(--footer-link, var(--color-link-light));
 }
 
 .bg-footer a:hover {
-    color: var(--footer-link-hover, var(--color-link-hover));
+    color: var(--footer-link-hover, var(--color-link-light));
 }
 
 .bg-dark {
@@ -1120,6 +1122,7 @@ main ol li::marker {
     color: var(--color-white);
 }
 
+/* Use light link color on dark backgrounds */
 .bg-dark a {
     color: var(--color-link-light);
 }


### PR DESCRIPTION
## Summary
- clarify that the "Link Color Light" customizer option also affects unordered list bullets
- note usage of the light link color in dynamic styles and theme stylesheets
- default dark footer and other dark sections to the light link color for readability

## Testing
- `php -l inc/customizer-options.php`
- `php -l inc/customizer-dynamic-styles.php`
- `npm test` *(fails: Missing script "test")*
- `npm run lint:scss` *(fails: wp-scripts: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c02feb929883308a6fa88b07819bcd