### PR TITLE
feat: apply muted color to small text

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -153,6 +153,11 @@ section p:not(.lead):not(.h2) {
     color: var(--color-text);
 }
 
+small,
+.text-muted {
+    color: var(--color-muted);
+}
+
 .blog-page h3 {
     color: var(--accent-secondary);
 }

--- a/style.css
+++ b/style.css
@@ -153,6 +153,11 @@ section p:not(.lead):not(.h2) {
     color: var(--color-text);
 }
 
+small,
+.text-muted {
+    color: var(--color-muted);
+}
+
 .blog-page h3 {
     color: var(--accent-secondary);
 }


### PR DESCRIPTION
## Summary
- use `--color-muted` for `<small>` and `.text-muted` elements

## Testing
- `npx -y stylelint style.css style-rtl.css` (fails: No configuration provided)
- `npm run compile:rtl` (fails: rtlcss: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c040053eac8330a6e74eabba85f237