### PR TITLE
Replace Bootstrap color classes with CSS variables

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -12,15 +12,15 @@ get_header();
 
 <div id="intro" class="carousel slide height-archive"></div><!-- #intro -->
 
-<main id="main" class="blog-page area-padding bg-light">
+<main id="main" class="blog-page area-padding" style="background-color: var(--bg-light);">
 	<div class="container">
 		<div class="row">
 			<!-- Breadcrumbs -->
 			<div id="breadcrumbs" class="col-12">
 				<nav aria-label="breadcrumb">
-					<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="bg-light breadcrumb">
+										<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--bg-light);">
 						<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
-                                                        <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>">
+														<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>">
 								<span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span>
 							</a>
 							<meta itemprop="position" content="1" />

--- a/page-fullwidth.php
+++ b/page-fullwidth.php
@@ -7,7 +7,7 @@
 
 get_header();
 ?>
-<div id="intro" class="pt-5 bg-cta">
+<div id="intro" class="pt-5" style="background-color: var(--cta-bg);">
 	<div class="container py-5 text-center">
 		<h1 class="title mt-2"><?php the_title(); ?></h1>
 		<a href="#main" class="btn-cta" rel="nofollow noopener" aria-label="<?php esc_attr_e( 'Go to main content', 'smile-web' ); ?>">
@@ -22,7 +22,7 @@ get_header();
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
 				<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb">
-                                        <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a><meta itemprop="position" content="1" />
+										<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a><meta itemprop="position" content="1" />
 					</li>
 					<?php if ( $post->post_parent ) { ?>
 					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
@@ -106,7 +106,7 @@ if ( is_page() && $post->post_parent ) {
 
 	if ( 0 !== $cat && get_posts( $args ) ) {
 		?>
-<section id="posts-relacionados" class="bg-light">
+<section id="posts-relacionados" style="background-color: var(--bg-light);">
 	<div class="container py-5">
 	<h4><?php echo wp_kses_post( $text_related ); ?></h4>
 	<hr>

--- a/page-sidebar.php
+++ b/page-sidebar.php
@@ -8,13 +8,13 @@ get_header();
 ?>
 <div id="intro" class="carousel slide height-archive">
 </div><!-- #intro -->
-<main id="main" class="blog-page area-padding bg-light2">
+<main id="main" class="blog-page area-padding" style="background-color: var(--bg-light2);">
 	<div class="container">
 		<div class="row">
 			<div id="breadcrumbs">
 				<nav aria-label="breadcrumb">
-					<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="bg-light2 breadcrumb">
-                                                <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name">Inicio</span></a>
+										<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--bg-light2);">
+												<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 							<meta itemprop="position" content="1" />
 						</li>
 						<?php if ( $post->post_parent ) { ?>
@@ -133,21 +133,21 @@ get_header();
 					$recent->the_post();
 					?>
 					<article class="blog-col col-md-4 col-sm-6 mb-4 mx-0">
-                                                <figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
-                                                        <?php
-                                                        $thumb_url = get_the_post_thumbnail_url( get_the_ID(), 'full' );
-                                                        $thumb_id  = get_post_thumbnail_id();
-                                                        $thumb_alt = $thumb_id ? get_post_meta( $thumb_id, '_wp_attachment_image_alt', true ) : '';
-                                                        if ( empty( $thumb_alt ) ) {
-                                                                $thumb_alt = get_the_title();
-                                                        }
-                                                        ?>
-                                                        <img class="img-fluid" src="<?php echo esc_url( $thumb_url ); ?>" alt="<?php echo esc_attr( $thumb_alt ); ?>">
-                                                </a>
-                                                <figcaption id="post-<?php the_ID(); ?>" class="p-4" style="color: var(--color-white);">
-                                                        <h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
-                                                        <p><?php the_excerpt(); ?></p>
-                                                        <hr>
+												<figure class="mb-0 shadow"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
+														<?php
+														$thumb_url = get_the_post_thumbnail_url( get_the_ID(), 'full' );
+														$thumb_id  = get_post_thumbnail_id();
+														$thumb_alt = $thumb_id ? get_post_meta( $thumb_id, '_wp_attachment_image_alt', true ) : '';
+														if ( empty( $thumb_alt ) ) {
+																$thumb_alt = get_the_title();
+														}
+														?>
+														<img class="img-fluid" src="<?php echo esc_url( $thumb_url ); ?>" alt="<?php echo esc_attr( $thumb_alt ); ?>">
+												</a>
+												<figcaption id="post-<?php the_ID(); ?>" class="p-4" style="color: var(--color-white);">
+														<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
+														<p><?php the_excerpt(); ?></p>
+														<hr>
 								<p><?php if ( ( get_the_modified_date( 'j F, Y' ) ) === ( get_the_date( 'j F, Y' ) ) ) { ?>
 										<span><b><?php esc_html_e( 'Published', 'smile-web' ); ?></b>: <?php the_modified_date( 'j F, Y' ); ?></span>
 									<?php } else { ?>

--- a/page.php
+++ b/page.php
@@ -12,7 +12,7 @@
 
 get_header();
 ?>
-<div id="intro" class="pt-5 bg-cta">
+<div id="intro" class="pt-5" style="background-color: var(--cta-bg);">
 	<div class="container py-5 text-center">
 		<h1 class="title mt-2"><?php the_title(); ?></h1>
 		<a href="#main" class="btn-cta" rel="nofollow noopener" aria-label="<?php esc_attr_e( 'Go to main content', 'smile-web' ); ?>">
@@ -42,12 +42,12 @@ get_header();
 		</figure>
 	<?php endif; // END if minimum width is 768px. ?>
 </div>
-<main id="main" class="bg-light">
+<main id="main" style="background-color: var(--bg-light);">
 	<div class="container py-2">
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
-				<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="bg-light breadcrumb">
-                                        <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name">Inicio</span></a>
+								<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--bg-light);">
+										<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 						<meta itemprop="position" content="1">
 					</li>
 					<?php if ( is_page() && 0 < $post->post_parent ) : ?>
@@ -139,7 +139,7 @@ get_header();
 	// If a category exists and posts exist in that category.
 	if ( 0 !== $category_id && get_posts( $args ) ) :
 		?>
-		<section id="posts-relacionados" class="bg-light">
+				<section id="posts-relacionados" style="background-color: var(--bg-light);">
 			<div class="container py-5">
 				<h4><?php echo wp_kses_post( $text_related ); ?></h4>
 				<hr>

--- a/single.php
+++ b/single.php
@@ -59,14 +59,14 @@ get_header();
 						<span> |
 							<?php
 							// SVG icon for comments.
-                                                        $comment_svg = '
+														$comment_svg = '
                                                         <svg style="fill: var(--color-white); width: 20px; height: 20px; position: relative; top: 5px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
 								<path d="M256 32C114.6 32 0 125.1 0 240c0 49.5 21.4 94.9 57.1 131.5-12.2 50.7-54.3 95.3-55 95.9C0 470.8-.5 471.3.3 472.6c.9 1.3 2.1 1.4 3.2 1.4 66.3 0 117.1-31.4 139.8-46.7 33.1 9.4 69 14.7 112.7 14.7 141.4 0 256-93.1 256-208S397.4 32 256 32z"/>
 							</svg>';
 							echo '<span class="svg-icon">' . wp_kses_post( $comment_svg ) . '</span>';
 							esc_html_e( 'Comments', 'smile-web' );
 							?>
-                                                        <a href="#comments" style="color: var(--color-white);"><?php echo esc_html( get_comments_number() ); ?></a>
+														<a href="#comments" style="color: var(--color-white);"><?php echo esc_html( get_comments_number() ); ?></a>
 						</span>
 					<?php endif; ?>
 				<?php endif; ?>
@@ -76,7 +76,7 @@ get_header();
 			$content = get_post_field( 'post_content', get_the_ID() );
 
 			// Contar las palabras del contenido.
-			$word_count = str_word_count( strip_tags( $content ) );
+						$word_count = str_word_count( wp_strip_all_tags( $content ) );
 
 			// Definir la velocidad de lectura promedio (250 palabras por minuto).
 			$reading_speed = 250;
@@ -90,7 +90,7 @@ get_header();
 		</div>
 	</div>
 </div><!-- #intro -->
-<main id="main" class="blog-page bg-light ">
+<main id="main" class="blog-page" style="background-color: var(--bg-light);">
 	<div class="container py-4">
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
@@ -98,18 +98,18 @@ get_header();
 					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 						<img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/solid/home.svg" alt="home" title="<?php esc_attr_e( 'Home', 'smile-web' ); ?>
 						" width="20px" height="20px">
-                                               <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" title="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>"><span><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
+												<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" title="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>"><span><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 						<meta itemprop="position" content="1" />
 					</li>
 					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 						<?php
 						$categories = get_the_category();
-                                                foreach ( $categories as $category ) {
-                                                        echo '<a itemid="' . esc_attr( $category->cat_name ) . '" href="' . esc_url( get_category_link( $category->term_id ) ) . '"><span>' . esc_html( $category->cat_name ) . '</span></a>';
-                                                }
-                                                ?>
-                                                <meta itemprop="position" content="2" />
-                                        </li>
+						foreach ( $categories as $category ) {
+								echo '<a itemid="' . esc_attr( $category->cat_name ) . '" href="' . esc_url( get_category_link( $category->term_id ) ) . '"><span>' . esc_html( $category->cat_name ) . '</span></a>';
+						}
+						?>
+												<meta itemprop="position" content="2" />
+										</li>
 					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><a href="<?php the_permalink(); ?>"><span><?php the_title(); ?></span></a>
 					</li>
 				</ol>
@@ -128,25 +128,25 @@ get_header();
 				<hr>
 				<!--Share Social Media -->
 				<div class="share-social-media">
-                                       <p><span><?php esc_html_e( 'Compartir:', 'smile-web' ); ?></span>
-                                               <a href="https://www.facebook.com/sharer/sharer.php?u=<?php echo esc_url( get_the_permalink() ); ?>"
-                                                       target="_blank" rel="noopener noreferrer">
+										<p><span><?php esc_html_e( 'Share:', 'smile-web' ); ?></span>
+												<a href="https://www.facebook.com/sharer/sharer.php?u=<?php echo esc_url( get_the_permalink() ); ?>"
+														target="_blank" rel="noopener noreferrer">
 
-                                                       <img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/brands/facebook.svg" alt="<?php esc_attr_e( 'Facebook', 'smile-web' ); ?>" title="<?php esc_attr_e( 'Share on Facebook', 'smile-web' ); ?>" width="20px" height="20px">
+														<img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/brands/facebook.svg" alt="<?php esc_attr_e( 'Facebook', 'smile-web' ); ?>" title="<?php esc_attr_e( 'Share on Facebook', 'smile-web' ); ?>" width="20px" height="20px">
 
-                                               </a> <a href="https://twitter.com/intent/tweet?url=<?php echo esc_url( get_the_permalink() ); ?>"
-                                                       target="_blank" rel="noopener noreferrer">
-                                                       <img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/brands/twitter.svg" alt="<?php esc_attr_e( 'Twitter', 'smile-web' ); ?>" title="<?php esc_attr_e( 'Share on Twitter', 'smile-web' ); ?>" width="20px" height="20px">
-                                               </a>
-                                               <a href="https://www.linkedin.com/cws/share?url=<?php echo esc_url( get_the_permalink() ); ?>"
-                                                       target="_blank" rel="noopener noreferrer">
-                                                       <img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/brands/linkedin.svg" alt="<?php esc_attr_e( 'LinkedIn', 'smile-web' ); ?>" title="<?php esc_attr_e( 'Share on LinkedIn', 'smile-web' ); ?>" width="20px" height="20px">
-                                               </a>
-                                               <a href="https://pinterest.com/pin/create/button/?url=<?php echo esc_url( get_the_permalink() ); ?>"
-                                                       target="_blank" rel="noopener noreferrer">
-                                                       <img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/brands/pinterest.svg" alt="<?php esc_attr_e( 'Pinterest', 'smile-web' ); ?>" title="<?php esc_attr_e( 'Share on Pinterest', 'smile-web' ); ?>" width="20px" height="20px">
-                                               </a>
-                                       </p>
+												</a> <a href="https://twitter.com/intent/tweet?url=<?php echo esc_url( get_the_permalink() ); ?>"
+														target="_blank" rel="noopener noreferrer">
+														<img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/brands/twitter.svg" alt="<?php esc_attr_e( 'Twitter', 'smile-web' ); ?>" title="<?php esc_attr_e( 'Share on Twitter', 'smile-web' ); ?>" width="20px" height="20px">
+												</a>
+												<a href="https://www.linkedin.com/cws/share?url=<?php echo esc_url( get_the_permalink() ); ?>"
+														target="_blank" rel="noopener noreferrer">
+														<img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/brands/linkedin.svg" alt="<?php esc_attr_e( 'LinkedIn', 'smile-web' ); ?>" title="<?php esc_attr_e( 'Share on LinkedIn', 'smile-web' ); ?>" width="20px" height="20px">
+												</a>
+												<a href="https://pinterest.com/pin/create/button/?url=<?php echo esc_url( get_the_permalink() ); ?>"
+														target="_blank" rel="noopener noreferrer">
+														<img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/brands/pinterest.svg" alt="<?php esc_attr_e( 'Pinterest', 'smile-web' ); ?>" title="<?php esc_attr_e( 'Share on Pinterest', 'smile-web' ); ?>" width="20px" height="20px">
+												</a>
+										</p>
 				</div>
 				<!--FIN Share Social Media -->
 					<?php
@@ -185,7 +185,7 @@ get_header();
 				'post__not_in'   => array( $current_post_id ),
 			);
 			?>
-	<section id="posts-relacionados" class="bg-light2">
+		<section id="posts-relacionados" style="background-color: var(--bg-light2);">
 		<div class="container py-5">
 			<p class="lead col-md-12 mb-5 border-bottom"><?php echo esc_html__( 'Related articles', 'smile-web' ); ?>
 			<?php

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -12,7 +12,7 @@
 
 ?>
 
-<article id="post-<?php the_ID(); ?>" class="row bg-white shadow mx-0 mb-4">
+<article id="post-<?php the_ID(); ?>" class="row shadow mx-0 mb-4" style="background-color: var(--color-white);">
 	<figure class="fit-figure p-0 m-0 col-md-4">
 		<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
 			<?php
@@ -24,7 +24,8 @@
 					$height = ! empty( $metadata['height'] ) ? $metadata['height'] : '';
 					$width  = ! empty( $metadata['width'] ) ? $metadata['width'] : '';
 				else :
-					$height = $width = '';
+										$height = '';
+										$width  = '';
 				endif;
 				$alt         = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
 				$image_title = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_title', true ) ) );


### PR DESCRIPTION
## Summary
- replace Bootstrap color classes with CSS variables and remove direct hex values in page, single, archive, and related templates
- translate breadcrumb home labels and share text to English
- sanitize reading time calculation with `wp_strip_all_tags`

## Testing
- `phpcs --standard=WordPress page.php single.php archive.php template-parts/content-search.php page-sidebar.php page-fullwidth.php`


------
https://chatgpt.com/codex/tasks/task_e_68c040e9e1a48330b68e4b7a43ea54cf