### PR TITLE
refactor: replace inline background styles with classes

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -12,13 +12,13 @@ get_header();
 
 <div id="intro" class="carousel slide height-archive"></div><!-- #intro -->
 
-<main id="main" class="blog-page area-padding" style="background-color: var(--bg-light);">
+<main id="main" class="blog-page area-padding bg-light">
 	<div class="container">
 		<div class="row">
 			<!-- Breadcrumbs -->
 			<div id="breadcrumbs" class="col-12">
 				<nav aria-label="breadcrumb">
-										<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--bg-light);">
+                                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb bg-light">
 						<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 														<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>">
 								<span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span>

--- a/page-fullwidth.php
+++ b/page-fullwidth.php
@@ -7,7 +7,7 @@
 
 get_header();
 ?>
-<div id="intro" class="pt-5" style="background-color: var(--cta-bg);">
+<div id="intro" class="pt-5 bg-cta">
 	<div class="container py-5 text-center">
 		<h1 class="title mt-2"><?php the_title(); ?></h1>
 		<a href="#main" class="btn-cta" rel="nofollow noopener" aria-label="<?php esc_attr_e( 'Go to main content', 'smile-web' ); ?>">
@@ -106,7 +106,7 @@ if ( is_page() && $post->post_parent ) {
 
 	if ( 0 !== $cat && get_posts( $args ) ) {
 		?>
-<section id="posts-relacionados" style="background-color: var(--bg-light);">
+<section id="posts-relacionados" class="bg-light">
 	<div class="container py-5">
 	<h4><?php echo wp_kses_post( $text_related ); ?></h4>
 	<hr>

--- a/page-sidebar.php
+++ b/page-sidebar.php
@@ -8,12 +8,12 @@ get_header();
 ?>
 <div id="intro" class="carousel slide height-archive">
 </div><!-- #intro -->
-<main id="main" class="blog-page area-padding" style="background-color: var(--bg-light2);">
+<main id="main" class="blog-page area-padding bg-light2">
 	<div class="container">
 		<div class="row">
 			<div id="breadcrumbs">
 				<nav aria-label="breadcrumb">
-										<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--bg-light2);">
+                                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb bg-light2">
 												<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 							<meta itemprop="position" content="1" />
 						</li>

--- a/single.php
+++ b/single.php
@@ -90,7 +90,7 @@ get_header();
 		</div>
 	</div>
 </div><!-- #intro -->
-<main id="main" class="blog-page" style="background-color: var(--bg-light);">
+<main id="main" class="blog-page bg-light">
 	<div class="container py-4">
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
@@ -185,7 +185,7 @@ get_header();
 				'post__not_in'   => array( $current_post_id ),
 			);
 			?>
-		<section id="posts-relacionados" style="background-color: var(--bg-light2);">
+               <section id="posts-relacionados" class="bg-light2">
 		<div class="container py-5">
 			<p class="lead col-md-12 mb-5 border-bottom"><?php echo esc_html__( 'Related articles', 'smile-web' ); ?>
 			<?php

--- a/style.css
+++ b/style.css
@@ -1080,12 +1080,13 @@ main ol li::marker {
 
 
 /* # 4.5 - BACKGROUND colors */
+
 .bg-light {
-    background: var(--bg-light);
+    background-color: var(--bg-light);
 }
 
 .bg-light2 {
-    background: var(--bg-light2);
+    background-color: var(--bg-light2);
 }
 
 .bg-white {
@@ -1094,7 +1095,7 @@ main ol li::marker {
 
 .bg-cta {
     /* Ensure CTA background maintains adequate contrast */
-    background: var(--cta-bg);
+    background-color: var(--cta-bg);
 }
 
 .bg-footer {


### PR DESCRIPTION
## Summary
- remove inline background styles from PHP templates and replace with bg-light/bg-light2/bg-cta classes
- define global background classes in `style.css`

## Testing
- `php -l single.php archive.php page-fullwidth.php page-sidebar.php`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:scss` *(fails: wp-scripts: not found; `npm install` failed due to distutils missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c123e9db0c83309e6cda6525cf934e