### PR TITLE
Use theme colors for comment links and captions

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -13,6 +13,7 @@ function smile_web_add_dynamic_styles() {
 	$color_link                   = sanitize_hex_color( get_theme_mod( 'color_link', '#307C03' ) );
 		$color_link_hover         = sanitize_hex_color( get_theme_mod( 'color_link_hover', '#306a93' ) );
 $color_link_light         = sanitize_hex_color( get_theme_mod( 'color_link_light', '#4a994f' ) );
+$comment_color            = sanitize_hex_color( get_theme_mod( 'comment_color', '#307C03' ) );
 $color_muted              = sanitize_hex_color( get_theme_mod( 'color_muted', '#6c757d' ) );
 $color_warning            = sanitize_hex_color( get_theme_mod( 'color_warning', '#ffc107' ) );
 $cta_bg                   = sanitize_hex_color( get_theme_mod( 'cta_bg', '#ffc107' ) );
@@ -55,7 +56,8 @@ $modal_border                 = sanitize_hex_color( '#888888' );
 			--color-link: ' . esc_attr( $color_link ) . ';
 --color-link-hover: ' . esc_attr( $color_link_hover ) . ';
 --color-link-light: ' . esc_attr( $color_link_light ) . ';
-   --color-muted: ' . esc_attr( $color_muted ) . ';
+                       --comment-color: ' . esc_attr( $comment_color ) . ';
+                       --color-muted: ' . esc_attr( $color_muted ) . ';
    --color-warning: ' . esc_attr( $color_warning ) . ';
    --cta-bg: ' . esc_attr( $cta_bg ) . ';
    --heading-color: ' . esc_attr( $heading_color ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -170,14 +170,18 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 				'default' => '#306a93',
 				'label'   => esc_html__( 'Link Color Hover', 'smile-web' ),
 			),
-			'color_link_light'      => array(
-				'default' => '#4a994f',
-				'label'   => esc_html__( 'Link Color Light', 'smile-web' ),
-			),
-			'color_muted'           => array(
-				'default' => '#6c757d',
-				'label'   => esc_html__( 'Muted Color', 'smile-web' ),
-			),
+                        'color_link_light'      => array(
+                                'default' => '#4a994f',
+                                'label'   => esc_html__( 'Link Color Light', 'smile-web' ),
+                        ),
+                        'comment_color'        => array(
+                                'default' => '#307C03',
+                                'label'   => esc_html__( 'Comment Color', 'smile-web' ),
+                        ),
+                        'color_muted'           => array(
+                                'default' => '#6c757d',
+                                'label'   => esc_html__( 'Muted Color', 'smile-web' ),
+                        ),
                         'color_warning'         => array(
                                 'default' => '#ffc107',
                                 'label'   => esc_html__( 'Warning Color', 'smile-web' ),

--- a/page-sidebar.php
+++ b/page-sidebar.php
@@ -144,7 +144,7 @@ get_header();
 														?>
 														<img class="img-fluid" src="<?php echo esc_url( $thumb_url ); ?>" alt="<?php echo esc_attr( $thumb_alt ); ?>">
 												</a>
-												<figcaption id="post-<?php the_ID(); ?>" class="p-4" style="color: var(--color-white);">
+                                                                                                <figcaption id="post-<?php the_ID(); ?>" class="p-4 figcaption-text">
 														<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
 														<p><?php the_excerpt(); ?></p>
 														<hr>

--- a/single.php
+++ b/single.php
@@ -60,13 +60,13 @@ get_header();
 							<?php
 							// SVG icon for comments.
 														$comment_svg = '
-                                                        <svg style="fill: var(--color-white); width: 20px; height: 20px; position: relative; top: 5px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                                                        <svg class="comment-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="20" height="20">
 								<path d="M256 32C114.6 32 0 125.1 0 240c0 49.5 21.4 94.9 57.1 131.5-12.2 50.7-54.3 95.3-55 95.9C0 470.8-.5 471.3.3 472.6c.9 1.3 2.1 1.4 3.2 1.4 66.3 0 117.1-31.4 139.8-46.7 33.1 9.4 69 14.7 112.7 14.7 141.4 0 256-93.1 256-208S397.4 32 256 32z"/>
 							</svg>';
 							echo '<span class="svg-icon">' . wp_kses_post( $comment_svg ) . '</span>';
 							esc_html_e( 'Comments', 'smile-web' );
 							?>
-														<a href="#comments" style="color: var(--color-white);"><?php echo esc_html( get_comments_number() ); ?></a>
+														<a href="#comments" class="comment-count"><?php echo esc_html( get_comments_number() ); ?></a>
 						</span>
 					<?php endif; ?>
 				<?php endif; ?>

--- a/style.css
+++ b/style.css
@@ -1310,6 +1310,22 @@ body.single .svg-icon svg {
     padding: 15px;
 }
 
+body.single .svg-icon .comment-icon {
+    fill: var(--comment-color);
+    position: relative;
+    top: 5px;
+    width: 20px;
+    height: 20px;
+}
+
+body.single .comment-count {
+    color: var(--comment-color);
+}
+
+.figcaption-text {
+    color: var(--color-text);
+}
+
 /* # 4.9 - SIDEBAR */
 .sidebar-menu {
     background-color: var(--color-white);


### PR DESCRIPTION
## Summary
- add `comment_color` global option and CSS variable
- style single post comment icon and count using `--comment-color`
- replace inline figcaption color with class using `--color-text`

## Testing
- `php -l single.php`
- `php -l page-sidebar.php`
- `php -l inc/customizer-options.php`
- `php -l inc/customizer-dynamic-styles.php`
- `npm test` *(fails: Missing script "test")*
- `npx stylelint style.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68c1264264d483308cb8581648830393