### PR TITLE
Use background classes for breadcrumb lists

### DIFF
--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@ $page_slug  = ( false !== $page_for_posts_id ) ? get_post_field( 'post_name', $p
 		<div class="container">
 			<div id="breadcrumbs">
 				<nav aria-label="<?php esc_attr_e( 'breadcrumb', 'smile-web' ); ?>">
-					<ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb">
+                                        <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb bg-light">
 						<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 							<img class="mx-2"
 								src="<?php echo esc_url( get_template_directory_uri() . '/lib/fontawesome-free/svgs/solid/home.svg' ); ?>"

--- a/page-fullwidth.php
+++ b/page-fullwidth.php
@@ -21,7 +21,7 @@ get_header();
 	<div class="container">
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
-				<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb">
+                                <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb bg-light">
 										<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a><meta itemprop="position" content="1" />
 					</li>
 					<?php if ( $post->post_parent ) { ?>

--- a/page.php
+++ b/page.php
@@ -46,7 +46,7 @@ get_header();
 	<div class="container py-2">
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
-								<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--bg-light);">
+                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb bg-light">
 										<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 						<meta itemprop="position" content="1">
 					</li>

--- a/single.php
+++ b/single.php
@@ -94,7 +94,7 @@ get_header();
 	<div class="container py-4">
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
-				<ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb">
+                                <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb bg-light">
 					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 						<img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/solid/home.svg" alt="home" title="<?php esc_attr_e( 'Home', 'smile-web' ); ?>
 						" width="20px" height="20px">


### PR DESCRIPTION
## Summary
- refactor breadcrumb markup to use bg-light utility classes instead of inline background styles

## Testing
- `php -l index.php`
- `php -l page.php`
- `php -l page-fullwidth.php`
- `php -l single.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1286dff3883309ed2ce25b529e773