### PR TITLE
feat: add custom card and comment colors

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -14,6 +14,7 @@ function smile_web_add_dynamic_styles() {
 		$color_link_hover         = sanitize_hex_color( get_theme_mod( 'color_link_hover', '#306a93' ) );
 $color_link_light         = sanitize_hex_color( get_theme_mod( 'color_link_light', '#4a994f' ) );
 $comment_color            = sanitize_hex_color( get_theme_mod( 'comment_color', '#307C03' ) );
+$card_text_color          = sanitize_hex_color( get_theme_mod( 'card_text_color', '#00112b' ) );
 $color_muted              = sanitize_hex_color( get_theme_mod( 'color_muted', '#6c757d' ) );
 $color_warning            = sanitize_hex_color( get_theme_mod( 'color_warning', '#ffc107' ) );
 $cta_bg                   = sanitize_hex_color( get_theme_mod( 'cta_bg', '#ffc107' ) );
@@ -57,6 +58,7 @@ $modal_border                 = sanitize_hex_color( '#888888' );
 --color-link-hover: ' . esc_attr( $color_link_hover ) . ';
 --color-link-light: ' . esc_attr( $color_link_light ) . ';
                        --comment-color: ' . esc_attr( $comment_color ) . ';
+                       --card-text-color: ' . esc_attr( $card_text_color ) . ';
                        --color-muted: ' . esc_attr( $color_muted ) . ';
    --color-warning: ' . esc_attr( $color_warning ) . ';
    --cta-bg: ' . esc_attr( $cta_bg ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -178,6 +178,10 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
                                 'default' => '#307C03',
                                 'label'   => esc_html__( 'Comment Color', 'smile-web' ),
                         ),
+                       'card_text_color'     => array(
+                               'default' => '#00112b',
+                               'label'   => esc_html__( 'Card Text Color', 'smile-web' ),
+                       ),
                         'color_muted'           => array(
                                 'default' => '#6c757d',
                                 'label'   => esc_html__( 'Muted Color', 'smile-web' ),

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1080,12 +1080,13 @@ main ol li::marker {
 
 
 /* # 4.5 - BACKGROUND colors */
+
 .bg-light {
-    background: var(--bg-light);
+    background-color: var(--bg-light);
 }
 
 .bg-light2 {
-    background: var(--bg-light2);
+    background-color: var(--bg-light2);
 }
 
 .bg-white {
@@ -1094,7 +1095,7 @@ main ol li::marker {
 
 .bg-cta {
     /* Ensure CTA background maintains adequate contrast */
-    background: var(--cta-bg);
+    background-color: var(--cta-bg);
 }
 
 .bg-footer {
@@ -1307,6 +1308,29 @@ body.single .svg-icon svg {
 .single #about .form-control {
     width: 100%;
     padding: 15px;
+}
+
+body.single .svg-icon .comment-icon {
+    fill: var(--comment-color);
+    position: relative;
+    top: 5px;
+    width: 20px;
+    height: 20px;
+}
+
+body.single .comment-count {
+    color: var(--comment-color);
+}
+
+.comment-metadata,
+.comment-metadata a,
+.comment-meta,
+.comment-meta a {
+    color: var(--comment-color);
+}
+
+.figcaption-text {
+    color: var(--card-text-color);
 }
 
 /* # 4.9 - SIDEBAR */

--- a/style.css
+++ b/style.css
@@ -1322,8 +1322,15 @@ body.single .comment-count {
     color: var(--comment-color);
 }
 
+.comment-metadata,
+.comment-metadata a,
+.comment-meta,
+.comment-meta a {
+    color: var(--comment-color);
+}
+
 .figcaption-text {
-    color: var(--color-text);
+    color: var(--card-text-color);
 }
 
 /* # 4.9 - SIDEBAR */


### PR DESCRIPTION
## Summary
- allow comment and card caption colors to be customized
- expose `--comment-color` and `--card-text-color` CSS variables
- apply variables to comment metadata and related-post captions

## Testing
- `php -l inc/customizer-options.php`
- `php -l inc/customizer-dynamic-styles.php`
- `npx rtlcss style.css style-rtl.css`
- `npx stylelint style.css` *(fails: No configuration provided)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c12c174ba883308bf3f44d0307a5ab