### PR TITLE
feat: add customizable text color variables

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -38,10 +38,10 @@ get_header();
 			<!-- Main Content -->
 			<div class="col-md-8">
 				<?php if ( have_posts() ) : ?>
-					<header class="archive-header mb-4">
-						<h1 class="archive-title"><?php the_archive_title(); ?></h1>
-						<p class="archive-description"><?php the_archive_description(); ?></p>
-					</header>
+                                        <header class="archive-header mb-4">
+                                                <h1 class="archive-title text-heading"><?php the_archive_title(); ?></h1>
+                                                <p class="archive-description text-subheading"><?php the_archive_description(); ?></p>
+                                        </header>
 					<div class="archive-posts">
 						<?php
 						while ( have_posts() ) :
@@ -59,7 +59,7 @@ get_header();
 						?>
 					</div>
 				<?php else : ?>
-					<h2 class="no-posts"><?php esc_html_e( 'No posts found.', 'smile-web' ); ?></h2>
+                                        <h2 class="no-posts text-heading"><?php esc_html_e( 'No posts found.', 'smile-web' ); ?></h2>
 				<?php endif; ?>
 			</div>
 

--- a/assets/css/editor-style.css
+++ b/assets/css/editor-style.css
@@ -1,7 +1,7 @@
 /* editor-style.css */
 body .editor-styles-wrapper {
     font-family: 'Roboto', sans-serif;
-    color: #05232c;
+    color: var(--text-base);
     background-color: #ffffff;
 }
 @font-face {
@@ -24,8 +24,12 @@ body .editor-styles-wrapper {
     font-style: normal;
   }
 /* Estilos para el editor */
-h1, h2, h3, h4, h5, h6 {
-    color: var(--color-text);
+h1 {
+    color: var(--text-heading);
+}
+
+h2, h3, h4, h5, h6 {
+    color: var(--text-subheading);
 }
 
 a {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -18,6 +18,60 @@
         # 10.0 - MODAL
 --------------------------------------------------------------*/
 
+body {
+  color: var(--text-base);
+}
+
+small {
+  color: var(--text-muted);
+}
+
+h1 {
+  color: var(--text-heading);
+}
+
+h2, h3, h4, h5, h6 {
+  color: var(--text-subheading);
+}
+
+blockquote {
+  color: var(--text-quote);
+}
+
+ul li {
+  color: var(--text-list);
+}
+
+strong,
+b,
+em {
+  color: var(--text-emphasis);
+}
+
+.text-base {
+  color: var(--text-base);
+}
+
+.text-heading {
+  color: var(--text-heading);
+}
+
+.text-subheading {
+  color: var(--text-subheading);
+}
+
+.text-emphasis {
+  color: var(--text-emphasis);
+}
+
+.text-quote {
+  color: var(--text-quote);
+}
+
+.text-list {
+  color: var(--text-list);
+}
+
 /*--------------------------------------------------------------
 # 4.5 - SIDEBAR + WIDGETS
 --------------------------------------------------------------*/
@@ -29,7 +83,7 @@
 }
 
 .sidebar-text {
-  color: var(--color-text-2)
+  color: var(--text-base)
 }
 
 .sidebar-border-bot {

--- a/front-page.php
+++ b/front-page.php
@@ -47,9 +47,9 @@ if ( 'yes' === $show_header_image && ! empty( $header_image ) ) {
 		<div class="row">
 			<div class="col-md-6">
 				<?php if ( 'custom' === $intro_content_type && ! empty( $intro_custom_title ) ) : ?>
-				<h1 class="title"><?php echo esc_html( $intro_custom_title ); ?></h1>
+                                <h1 class="text-heading"><?php echo esc_html( $intro_custom_title ); ?></h1>
 				<?php else : ?>
-				<h1 class="title"><?php the_title(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h1>
+                                <h1 class="text-heading"><?php the_title(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h1>
 				<?php endif; ?>
 
 				<?php if ( 'custom' === $intro_content_type && ! empty( $intro_custom_description ) ) : ?>
@@ -100,10 +100,10 @@ if ( 'yes' === $show_header_image && ! empty( $header_image ) ) {
 		?>
 	<section id="posts-relacionados" class="bg-light2">
 		<div class="container py-5 text-center">
-			<p class="lead pb-2 border-bottom">
+                    <p class="text-emphasis pb-2 border-bottom">
 				<?php echo esc_html( $custom_blog_title ); ?>
 			</p>
-			<p class="lead">
+                    <p class="text-emphasis">
 				<?php echo esc_html( $blog_description ); ?>
 			</p>
 		</div>
@@ -157,7 +157,7 @@ if ( 'yes' === $show_header_image && ! empty( $header_image ) ) {
 						</a>
 
 						<figcaption class="bg-white px-4">
-							<p class="lead">
+                                                    <p class="text-emphasis">
 								<a href="<?php the_permalink(); ?>" rel="bookmark">
 									<?php the_title(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 								</a>

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -9,18 +9,21 @@
  * Outputs inline dynamic CSS based on customizer settings.
  */
 function smile_web_add_dynamic_styles() {
-	$color_text                   = sanitize_hex_color( get_theme_mod( 'color_text', '#00112b' ) );
-	$color_link                   = sanitize_hex_color( get_theme_mod( 'color_link', '#307C03' ) );
-		$color_link_hover         = sanitize_hex_color( get_theme_mod( 'color_link_hover', '#306a93' ) );
-$color_link_light         = sanitize_hex_color( get_theme_mod( 'color_link_light', '#4a994f' ) );
-$comment_color            = sanitize_hex_color( get_theme_mod( 'comment_color', '#307C03' ) );
-$card_text_color          = sanitize_hex_color( get_theme_mod( 'card_text_color', '#00112b' ) );
-$color_muted              = sanitize_hex_color( get_theme_mod( 'color_muted', '#6c757d' ) );
-$color_warning            = sanitize_hex_color( get_theme_mod( 'color_warning', '#ffc107' ) );
-$cta_bg                   = sanitize_hex_color( get_theme_mod( 'cta_bg', '#ffc107' ) );
-$heading_color            = sanitize_hex_color( get_theme_mod( 'heading_color', '#306a93' ) );
-$lead_color               = sanitize_hex_color( get_theme_mod( 'lead_color', '#306a93' ) );
-$breadcrumb_separator     = sanitize_text_field( get_theme_mod( 'breadcrumb_separator', '/' ) );
+        $color_link                   = sanitize_hex_color( get_theme_mod( 'color_link', '#307C03' ) );
+        $color_link_hover             = sanitize_hex_color( get_theme_mod( 'color_link_hover', '#306a93' ) );
+        $color_link_light             = sanitize_hex_color( get_theme_mod( 'color_link_light', '#4a994f' ) );
+        $comment_color                = sanitize_hex_color( get_theme_mod( 'comment_color', '#307C03' ) );
+        $card_text_color              = sanitize_hex_color( get_theme_mod( 'card_text_color', '#00112b' ) );
+        $color_warning                = sanitize_hex_color( get_theme_mod( 'color_warning', '#ffc107' ) );
+        $cta_bg                       = sanitize_hex_color( get_theme_mod( 'cta_bg', '#ffc107' ) );
+        $breadcrumb_separator         = sanitize_text_field( get_theme_mod( 'breadcrumb_separator', '/' ) );
+        $text_base                    = sanitize_hex_color( get_theme_mod( 'text_base', '#00112b' ) );
+        $text_muted                   = sanitize_hex_color( get_theme_mod( 'text_muted', '#6c757d' ) );
+        $text_heading                 = sanitize_hex_color( get_theme_mod( 'text_heading', '#306a93' ) );
+        $text_subheading              = sanitize_hex_color( get_theme_mod( 'text_subheading', '#225274' ) );
+        $text_emphasis                = sanitize_hex_color( get_theme_mod( 'text_emphasis', '#307C03' ) );
+        $text_quote                   = sanitize_hex_color( get_theme_mod( 'text_quote', '#225274' ) );
+        $text_list                    = sanitize_hex_color( get_theme_mod( 'text_list', '#00112b' ) );
 		$accent_primary_light     = sanitize_hex_color( get_theme_mod( 'accent-primary-light', '#d2e1ef' ) );
 		$accent_primary           = sanitize_hex_color( get_theme_mod( 'accent-primary', '#d2e1ef' ) );
 		$accent_secondary         = sanitize_hex_color( get_theme_mod( 'accent-secondary', '#225274' ) );
@@ -53,18 +56,21 @@ $modal_border                 = sanitize_hex_color( '#888888' );
 
 	$dynamic_css = '
 		:root {
-			--color-text: ' . esc_attr( $color_text ) . ';
-			--color-link: ' . esc_attr( $color_link ) . ';
---color-link-hover: ' . esc_attr( $color_link_hover ) . ';
---color-link-light: ' . esc_attr( $color_link_light ) . ';
-                       --comment-color: ' . esc_attr( $comment_color ) . ';
-                       --card-text-color: ' . esc_attr( $card_text_color ) . ';
-                       --color-muted: ' . esc_attr( $color_muted ) . ';
-   --color-warning: ' . esc_attr( $color_warning ) . ';
-   --cta-bg: ' . esc_attr( $cta_bg ) . ';
-   --heading-color: ' . esc_attr( $heading_color ) . ';
-   --lead-color: ' . esc_attr( $lead_color ) . ';
-   --breadcrumb-separator: "' . esc_attr( $breadcrumb_separator ) . '";
+                        --color-link: ' . esc_attr( $color_link ) . ';
+                        --color-link-hover: ' . esc_attr( $color_link_hover ) . ';
+                        --color-link-light: ' . esc_attr( $color_link_light ) . ';
+                        --comment-color: ' . esc_attr( $comment_color ) . ';
+                        --card-text-color: ' . esc_attr( $card_text_color ) . ';
+                        --color-warning: ' . esc_attr( $color_warning ) . ';
+                        --cta-bg: ' . esc_attr( $cta_bg ) . ';
+                        --breadcrumb-separator: "' . esc_attr( $breadcrumb_separator ) . '";
+                        --text-base: ' . esc_attr( $text_base ) . ';
+                        --text-muted: ' . esc_attr( $text_muted ) . ';
+                        --text-heading: ' . esc_attr( $text_heading ) . ';
+                        --text-subheading: ' . esc_attr( $text_subheading ) . ';
+                        --text-emphasis: ' . esc_attr( $text_emphasis ) . ';
+                        --text-quote: ' . esc_attr( $text_quote ) . ';
+                        --text-list: ' . esc_attr( $text_list ) . ';
                        --accent-primary-light: ' . esc_attr( $accent_primary_light ) . ';
                        --accent-primary: ' . esc_attr( $accent_primary ) . ';
                        --accent-secondary: ' . esc_attr( $accent_secondary ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -182,10 +182,38 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
                                'default' => '#00112b',
                                'label'   => esc_html__( 'Card Text Color', 'smile-web' ),
                        ),
-                        'color_muted'           => array(
-                                'default' => '#6c757d',
-                                'label'   => esc_html__( 'Muted Color', 'smile-web' ),
-                        ),
+                       'text_base'           => array(
+                               'default' => '#00112b',
+                               'label'   => esc_html__( 'Base Text Color', 'smile-web' ),
+                       ),
+                       'text_muted'          => array(
+                               'default' => '#6c757d',
+                               'label'   => esc_html__( 'Muted Text Color', 'smile-web' ),
+                       ),
+                       'text_heading'        => array(
+                               'default' => '#306a93',
+                               'label'   => esc_html__( 'Heading Text Color', 'smile-web' ),
+                       ),
+                       'text_subheading'     => array(
+                               'default' => '#225274',
+                               'label'   => esc_html__( 'Subheading Text Color', 'smile-web' ),
+                       ),
+                       'text_emphasis'       => array(
+                               'default' => '#307C03',
+                               'label'   => esc_html__( 'Emphasis Text Color', 'smile-web' ),
+                       ),
+                       'text_quote'          => array(
+                               'default' => '#225274',
+                               'label'   => esc_html__( 'Quote Text Color', 'smile-web' ),
+                       ),
+                       'text_list'           => array(
+                               'default' => '#00112b',
+                               'label'   => esc_html__( 'List Text Color', 'smile-web' ),
+                       ),
+                       'color_muted'           => array(
+                               'default' => '#6c757d',
+                               'label'   => esc_html__( 'Muted Color', 'smile-web' ),
+                       ),
                         'color_warning'         => array(
                                 'default' => '#ffc107',
                                 'label'   => esc_html__( 'Warning Color', 'smile-web' ),

--- a/inc/enqueues.php
+++ b/inc/enqueues.php
@@ -271,7 +271,7 @@ function smile_v6_enqueue_scripts() {
     content: var(--breadcrumb-separator);
     float: left;
     padding-right: 0.5rem;
-    color: var(--color-muted);
+    color: var(--text-muted);
 }
 .breadcrumb {
     display: flex;
@@ -344,7 +344,7 @@ function smile_v6_enqueue_scripts() {
     content: var(--breadcrumb-separator);
     float: left;
     padding-right: 0.5rem;
-    color: var(--color-muted);
+    color: var(--text-muted);
 }
 .breadcrumb {
     display: flex;

--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@ $page_slug  = ( false !== $page_for_posts_id ) ? get_post_field( 'post_name', $p
 ?>
 <div id="intro">
 	<div class="text-center py-5">
-		<h1><?php echo esc_html( $page_title ); ?></h1>
+                <h1 class="text-heading"><?php echo esc_html( $page_title ); ?></h1>
 		<p class="text-center mt-4">
 			<a href="#contact" class="btn-cta" rel="nofollow noreferrer">
                                <?php esc_html_e( 'Contact us', 'smile-web' ); ?>
@@ -152,7 +152,7 @@ $page_slug  = ( false !== $page_for_posts_id ) ? get_post_field( 'post_name', $p
                                                                                                         height="400">
                                                                                         </a>
                                                                                         <figcaption class="bg-white px-4">
-                                                                                                <p class="lead">
+                                                                                                <p class="text-emphasis">
                                                                                                         <a href="<?php the_permalink(); ?>"
                                                                                                                 rel="bookmark"
                                                                                                                 title="<?php echo esc_attr( get_the_title() ); ?>">

--- a/page-fullwidth.php
+++ b/page-fullwidth.php
@@ -9,7 +9,7 @@ get_header();
 ?>
 <div id="intro" class="pt-5 bg-cta">
 	<div class="container py-5 text-center">
-		<h1 class="title mt-2"><?php the_title(); ?></h1>
+                <h1 class="text-heading mt-2"><?php the_title(); ?></h1>
 		<a href="#main" class="btn-cta" rel="nofollow noopener" aria-label="<?php esc_attr_e( 'Go to main content', 'smile-web' ); ?>">
 			<?php esc_html_e( 'See main content', 'smile-web' ); ?>
 		</a>

--- a/page-sidebar.php
+++ b/page-sidebar.php
@@ -39,7 +39,7 @@ get_header();
 		<div class="row">
 			<!-- Start single post -->
 			<article id="post-<?php the_ID(); ?>" class="entry-content col-md-8">
-				<h1 class="title"><?php the_title(); ?></h1>
+                                <h1 class="text-heading"><?php the_title(); ?></h1>
 				<?php
 				the_content();
 

--- a/search.php
+++ b/search.php
@@ -11,8 +11,8 @@ get_header();
 ?>
 <section id="intro">
 <div class="container">
-       <p class="lead mt-4"> <?php esc_html_e( 'Search:', 'smile-web' ); ?> </p>
-	<h1 class="page-title"> <?php echo esc_html( get_search_query() ); ?> </h1>
+       <p class="text-emphasis mt-4"> <?php esc_html_e( 'Search:', 'smile-web' ); ?> </p>
+        <h1 class="page-title text-heading"> <?php echo esc_html( get_search_query() ); ?> </h1>
 </div><!-- .page-header -->
 
 </section>

--- a/single.php
+++ b/single.php
@@ -12,7 +12,7 @@ get_header();
 <div id="intro" class="pt-5">
 	<div class="container py-3">
 		<div class="row text-center py-2">
-			<h1 class="title my-2"><?php the_title(); ?></h1>
+                        <h1 class="text-heading my-2"><?php the_title(); ?></h1>
 			<div class="entry-header d-flex justify-content-center">
 				<?php if ( is_single() ) : ?>
 					<span>
@@ -187,7 +187,7 @@ get_header();
 			?>
                <section id="posts-relacionados" class="bg-light2">
 		<div class="container py-5">
-			<p class="lead col-md-12 mb-5 border-bottom"><?php echo esc_html__( 'Related articles', 'smile-web' ); ?>
+                        <p class="text-emphasis col-md-12 mb-5 border-bottom"><?php echo esc_html__( 'Related articles', 'smile-web' ); ?>
 			<?php
 			$categories = get_the_category();
 			foreach ( $categories as $category ) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -116,6 +116,7 @@ body {
     margin: 0;
     font-family: var(--font-family);
     line-height: 1.7em;
+    color: var(--text-base);
 }
 
 
@@ -123,11 +124,9 @@ body {
 /*--------------------------------------------------------------
 # 1.1 - HEADERS H1, H2, H3, P
 --------------------------------------------------------------*/
-h1,
-h2,
-.h2 {
+h1 {
     line-height: 1.1em;
-    color: var(--heading-color);
+    color: var(--text-heading);
     font-family: var(--font-family-bold);
     padding-top: 0;
     margin: 0;
@@ -137,11 +136,18 @@ h2,
 
 h2,
 .h2 {
+    line-height: 1.1em;
+    color: var(--text-subheading);
+    font-family: var(--font-family-bold);
+    padding-top: 0;
+    margin: 0;
+    padding-bottom: 10px;
+    width: 100%;
     font-size: 36px;
 }
 
 h3 {
-    color: var(--accent-secondary);
+    color: var(--text-subheading);
     line-height: 1.2em;
 }
 
@@ -149,17 +155,45 @@ p {
     width: 100%;
 }
 
-section p:not(.lead):not(.h2) {
-    color: var(--color-text);
+section p:not(.text-emphasis):not(.h2) {
+    color: var(--text-base);
 }
 
 small,
 .text-muted {
-    color: var(--color-muted);
+    color: var(--text-muted);
+}
+
+.text-base {
+    color: var(--text-base);
+}
+
+.text-heading {
+    color: var(--text-heading);
+}
+
+.text-subheading {
+    color: var(--text-subheading);
+}
+
+blockquote,
+.text-quote {
+    color: var(--text-quote);
+}
+
+ul li,
+.text-list {
+    color: var(--text-list);
+}
+
+em,
+strong,
+b {
+    color: var(--text-emphasis);
 }
 
 .blog-page h3 {
-    color: var(--accent-secondary);
+    color: var(--text-subheading);
 }
 
 /*--------------------------------------------------------------
@@ -1044,9 +1078,9 @@ main ol li::marker {
     border: 1px solid var(--border-color) !important;
 }
 
-.lead {
+.text-emphasis {
     font-weight: 200;
-    color: var(--lead-color);
+    color: var(--text-emphasis);
     font-size: 22px;
     line-height: 1.2em;
     margin-bottom: 30px;
@@ -1226,7 +1260,7 @@ main ol li::marker {
 .close:focus,
 .close2:hover,
 .close2:focus {
-    color: var(--color-text);
+    color: var(--text-base);
     text-decoration: none;
     cursor: pointer;
 }
@@ -1245,7 +1279,7 @@ main ol li::marker {
 .modal-footer {
     padding: 2px 16px;
     background-color: var(--color-white);
-    color: var(--color-text);
+    color: var(--text-base);
     min-height: 50px;
 }
 
@@ -1341,7 +1375,7 @@ body.single .comment-count {
 }
 
 .sidebar-text {
-    color: var(--color-text)
+    color: var(--text-base)
 }
 
 .sidebar-border-bot {

--- a/style.css
+++ b/style.css
@@ -116,6 +116,7 @@ body {
     margin: 0;
     font-family: var(--font-family);
     line-height: 1.7em;
+    color: var(--text-base);
 }
 
 
@@ -123,11 +124,9 @@ body {
 /*--------------------------------------------------------------
 # 1.1 - HEADERS H1, H2, H3, P
 --------------------------------------------------------------*/
-h1,
-h2,
-.h2 {
+h1 {
     line-height: 1.1em;
-    color: var(--heading-color);
+    color: var(--text-heading);
     font-family: var(--font-family-bold);
     padding-top: 0;
     margin: 0;
@@ -137,11 +136,18 @@ h2,
 
 h2,
 .h2 {
+    line-height: 1.1em;
+    color: var(--text-subheading);
+    font-family: var(--font-family-bold);
+    padding-top: 0;
+    margin: 0;
+    padding-bottom: 10px;
+    width: 100%;
     font-size: 36px;
 }
 
 h3 {
-    color: var(--accent-secondary);
+    color: var(--text-subheading);
     line-height: 1.2em;
 }
 
@@ -149,17 +155,45 @@ p {
     width: 100%;
 }
 
-section p:not(.lead):not(.h2) {
-    color: var(--color-text);
+section p:not(.text-emphasis):not(.h2) {
+    color: var(--text-base);
 }
 
 small,
 .text-muted {
-    color: var(--color-muted);
+    color: var(--text-muted);
+}
+
+.text-base {
+    color: var(--text-base);
+}
+
+.text-heading {
+    color: var(--text-heading);
+}
+
+.text-subheading {
+    color: var(--text-subheading);
+}
+
+blockquote,
+.text-quote {
+    color: var(--text-quote);
+}
+
+ul li,
+.text-list {
+    color: var(--text-list);
+}
+
+em,
+strong,
+b {
+    color: var(--text-emphasis);
 }
 
 .blog-page h3 {
-    color: var(--accent-secondary);
+    color: var(--text-subheading);
 }
 
 /*--------------------------------------------------------------
@@ -1044,9 +1078,9 @@ main ol li::marker {
     border: 1px solid var(--border-color) !important;
 }
 
-.lead {
+.text-emphasis {
     font-weight: 200;
-    color: var(--lead-color);
+    color: var(--text-emphasis);
     font-size: 22px;
     line-height: 1.2em;
     margin-bottom: 30px;
@@ -1226,7 +1260,7 @@ main ol li::marker {
 .close:focus,
 .close2:hover,
 .close2:focus {
-    color: var(--color-text);
+    color: var(--text-base);
     text-decoration: none;
     cursor: pointer;
 }
@@ -1245,7 +1279,7 @@ main ol li::marker {
 .modal-footer {
     padding: 2px 16px;
     background-color: var(--color-white);
-    color: var(--color-text);
+    color: var(--text-base);
     min-height: 50px;
 }
 
@@ -1341,7 +1375,7 @@ body.single .comment-count {
 }
 
 .sidebar-text {
-    color: var(--color-text)
+    color: var(--text-base)
 }
 
 .sidebar-border-bot {


### PR DESCRIPTION
## Summary
- add Customizer settings for base, muted, heading, subheading, emphasis, quote, and list text colors
- expose new text color CSS variables and apply them across stylesheets
- update templates to use new text color classes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:js` *(fails: wp-scripts: not found)*
- `php -l inc/customizer-options.php inc/customizer-dynamic-styles.php inc/enqueues.php single.php archive.php page-fullwidth.php page-sidebar.php front-page.php index.php search.php`


------
https://chatgpt.com/codex/tasks/task_e_68c139d25e048330b920464448ca9ae8