### PR TITLE
feat: add customizable link color variables

### DIFF
--- a/assets/css/editor-style.css
+++ b/assets/css/editor-style.css
@@ -33,15 +33,15 @@ h2, h3, h4, h5, h6 {
 }
 
 a {
-    color: var(--color-link);
+    color: var(--link);
 }
 
 a:hover {
-    color: var(--color-link-hover);
+    color: var(--link-hover);
 }
 
 button, .button {
-    background-color: var(--color-link);
+    background-color: var(--link);
     color: var(--color-white);
     border-radius: 5px;
     padding: 10px 20px;
@@ -49,7 +49,7 @@ button, .button {
 }
 
 button:hover, .button:hover {
-    background-color: var(--color-link-hover);
+    background-color: var(--link-hover);
 }
 
 blockquote {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -104,7 +104,7 @@ em {
 }
 
 #footer .fa:hover {
-  color: var(--color-link)
+  color: var(--link)
 }
 
 #footer .footer-top a {
@@ -140,7 +140,7 @@ em {
 }
 
 #footer #menu-redes-sociales-1 li a:hover {
-  color: var(--color-link);
+  color: var(--link);
 }
 
 #topBar {
@@ -187,7 +187,7 @@ em {
 
 #footer-bottom {
   padding: 30px 0;
-  background-color: var(--color-link-hover);
+  background-color: var(--link-hover);
   color: #fff;
 }
 
@@ -258,12 +258,12 @@ em {
 }
 
 .post-categories li {
-  background-color: var(--color-link-hover);
+  background-color: var(--link-hover);
   margin-right: 5px;
 }
 
 .post-categories li:hover {
-  background-color: var(--color-link);
+  background-color: var(--link);
 }
 
 .post-categories li a {

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -9,9 +9,10 @@
  * Outputs inline dynamic CSS based on customizer settings.
  */
 function smile_web_add_dynamic_styles() {
-        $color_link                   = sanitize_hex_color( get_theme_mod( 'color_link', '#307C03' ) );
-        $color_link_hover             = sanitize_hex_color( get_theme_mod( 'color_link_hover', '#306a93' ) );
-        $color_link_light             = sanitize_hex_color( get_theme_mod( 'color_link_light', '#4a994f' ) );
+        $link_default                = sanitize_hex_color( get_theme_mod( 'link_default', '#307C03' ) );
+        $link_hover                  = sanitize_hex_color( get_theme_mod( 'link_hover', '#306a93' ) );
+        $link_active                 = sanitize_hex_color( get_theme_mod( 'link_active', '#4a994f' ) );
+        $link_visited                = sanitize_hex_color( get_theme_mod( 'link_visited', '#4a994f' ) );
         $comment_color                = sanitize_hex_color( get_theme_mod( 'comment_color', '#307C03' ) );
         $card_text_color              = sanitize_hex_color( get_theme_mod( 'card_text_color', '#00112b' ) );
         $color_warning                = sanitize_hex_color( get_theme_mod( 'color_warning', '#ffc107' ) );
@@ -54,11 +55,12 @@ $color_white                  = sanitize_hex_color( '#FFFFFF' );
 $border_color                 = sanitize_hex_color( get_theme_mod( 'border_color', '#dee2e6' ) );
 $modal_border                 = sanitize_hex_color( '#888888' );
 
-	$dynamic_css = '
-		:root {
-                        --color-link: ' . esc_attr( $color_link ) . ';
-                        --color-link-hover: ' . esc_attr( $color_link_hover ) . ';
-                        --color-link-light: ' . esc_attr( $color_link_light ) . ';
+        $dynamic_css = '
+                :root {
+                        --link: ' . esc_attr( $link_default ) . ';
+                        --link-hover: ' . esc_attr( $link_hover ) . ';
+                        --link-active: ' . esc_attr( $link_active ) . ';
+                        --link-visited: ' . esc_attr( $link_visited ) . ';
                         --comment-color: ' . esc_attr( $comment_color ) . ';
                         --card-text-color: ' . esc_attr( $card_text_color ) . ';
                         --color-warning: ' . esc_attr( $color_warning ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -162,18 +162,22 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
                                 'default' => '#00112b',
                                 'label'   => esc_html__( 'Text Color', 'smile-web' ),
                         ),
-			'color_link'            => array(
-				'default' => '#307C03',
-				'label'   => esc_html__( 'Link Color', 'smile-web' ),
-			),
-			'color_link_hover'      => array(
-				'default' => '#306a93',
-				'label'   => esc_html__( 'Link Color Hover', 'smile-web' ),
-			),
-                        'color_link_light'      => array(
-                                'default' => '#4a994f',
-                                'label'   => esc_html__( 'Link Color Light', 'smile-web' ),
-                        ),
+                       'link_default'         => array(
+                               'default' => '#307C03',
+                               'label'   => esc_html__( 'Link Color', 'smile-web' ),
+                       ),
+                       'link_hover'           => array(
+                               'default' => '#306a93',
+                               'label'   => esc_html__( 'Link Hover Color', 'smile-web' ),
+                       ),
+                       'link_active'          => array(
+                               'default' => '#4a994f',
+                               'label'   => esc_html__( 'Link Active Color', 'smile-web' ),
+                       ),
+                       'link_visited'         => array(
+                               'default' => '#4a994f',
+                               'label'   => esc_html__( 'Link Visited Color', 'smile-web' ),
+                       ),
                         'comment_color'        => array(
                                 'default' => '#307C03',
                                 'label'   => esc_html__( 'Comment Color', 'smile-web' ),

--- a/inc/enqueues.php
+++ b/inc/enqueues.php
@@ -101,8 +101,8 @@ function smile_v6_enqueue_scripts() {
     align-items: center;
 }
 .btn-featured {
-    border: 1px solid var(--color-link);
-    color: var(--color-link);
+    border: 1px solid var(--link);
+    color: var(--link);
     padding: 2px 5px;
     margin: 0;
     border-radius: 5px;
@@ -114,7 +114,7 @@ function smile_v6_enqueue_scripts() {
     text-decoration: none;
 }
 .btn-featured:hover {
-    background: var(--color-link);
+    background: var(--link);
     color: var(--color-white);
 }
 .bar1,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -49,7 +49,7 @@ Use it to make something cool, have fun, and share what you've learned.
 /* Galería de imágenes Hermandad */
 #bwg_container1_0 #bwg_container2_0 .bwg-container-0.bwg-masonry-thumbnails .bwg-title2 {
     font-size: 16px !important;
-    color: var(--color-link) !important;
+    color: var(--link) !important;
 }
 
 .bwg-item {
@@ -200,12 +200,20 @@ b {
 # 1.2 - LINKS
 --------------------------------------------------------------*/
 a {
-    color: var(--color-link);
+    color: var(--link);
 }
 
 a:hover {
     text-decoration: none;
-    color: var(--color-link-hover);
+    color: var(--link-hover);
+}
+
+a:focus {
+    color: var(--link-active);
+}
+
+a:visited {
+    color: var(--link-visited);
 }
 
 #contact a {
@@ -226,10 +234,10 @@ a:hover {
     font-weight: 500;
     font-size: 12px;
     letter-spacing: 1px;
-    background-color: var(--color-link);
+    background-color: var(--link);
     color: var(--color-white);
     text-decoration: none;
-    border: 1px solid var(--color-link);
+    border: 1px solid var(--link);
 }
 
 @media (min-width:768px) {
@@ -248,8 +256,8 @@ a:hover {
 .wp-block-buttons>.wp-block-button:hover,
 .btn-cta:hover {
     background-color: var(--color-white);
-    color: var(--color-link);
-    border: 1px solid var(--color-link);
+    color: var(--link);
+    border: 1px solid var(--link);
 }
 
 .btn-cta2 {
@@ -960,7 +968,7 @@ section h2 {
 .container .header {
     text-align: center;
     margin-bottom: 50px;
-    color: var(--color-link-hover);
+    color: var(--link-hover);
     font-size: 1.2em;
 }
 
@@ -1042,7 +1050,7 @@ main li {
 main section ul li::before,
 main article ul li::before {
     content: "• ";
-    color: var(--color-link-light);
+    color: var(--link-active);
     font-size: 3em;
     position: relative;
     top: 0.25em;
@@ -1138,11 +1146,11 @@ main ol li::marker {
 }
 
 .bg-footer a {
-    color: var(--footer-link, var(--color-link));
+    color: var(--footer-link, var(--link));
 }
 
 .bg-footer a:hover {
-    color: var(--footer-link-hover, var(--color-link-hover));
+    color: var(--footer-link-hover, var(--link-hover));
 }
 
 .bg-dark {
@@ -1161,7 +1169,7 @@ main ol li::marker {
 }
 
 .bg-dark a {
-    color: var(--color-link-light);
+    color: var(--link-active);
 }
 
 
@@ -1571,7 +1579,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-newsletter input[type=submit] {
-    background: var(--color-link);
+    background: var(--link);
     border: 0;
     width: 35%;
     padding: 6px 0;
@@ -1584,7 +1592,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-newsletter input[type=submit]:hover {
-    background: var(--color-link-hover)
+    background: var(--link-hover)
 }
 
 #footer .copyright {

--- a/style.css
+++ b/style.css
@@ -49,7 +49,7 @@ Use it to make something cool, have fun, and share what you've learned.
 /* Galería de imágenes Hermandad */
 #bwg_container1_0 #bwg_container2_0 .bwg-container-0.bwg-masonry-thumbnails .bwg-title2 {
     font-size: 16px !important;
-    color: var(--color-link) !important;
+    color: var(--link) !important;
 }
 
 .bwg-item {
@@ -200,12 +200,20 @@ b {
 # 1.2 - LINKS
 --------------------------------------------------------------*/
 a {
-    color: var(--color-link);
+    color: var(--link);
 }
 
 a:hover {
     text-decoration: none;
-    color: var(--color-link-hover);
+    color: var(--link-hover);
+}
+
+a:focus {
+    color: var(--link-active);
+}
+
+a:visited {
+    color: var(--link-visited);
 }
 
 #contact a {
@@ -226,10 +234,10 @@ a:hover {
     font-weight: 500;
     font-size: 12px;
     letter-spacing: 1px;
-    background-color: var(--color-link);
+    background-color: var(--link);
     color: var(--color-white);
     text-decoration: none;
-    border: 1px solid var(--color-link);
+    border: 1px solid var(--link);
 }
 
 @media (min-width:768px) {
@@ -248,8 +256,8 @@ a:hover {
 .wp-block-buttons>.wp-block-button:hover,
 .btn-cta:hover {
     background-color: var(--color-white);
-    color: var(--color-link);
-    border: 1px solid var(--color-link);
+    color: var(--link);
+    border: 1px solid var(--link);
 }
 
 .btn-cta2 {
@@ -960,7 +968,7 @@ section h2 {
 .container .header {
     text-align: center;
     margin-bottom: 50px;
-    color: var(--color-link-hover);
+    color: var(--link-hover);
     font-size: 1.2em;
 }
 
@@ -1042,7 +1050,7 @@ main li {
 main section ul li::before,
 main article ul li::before {
     content: "• ";
-    color: var(--color-link-light);
+    color: var(--link-active);
     font-size: 3em;
     position: relative;
     top: 0.25em;
@@ -1138,11 +1146,11 @@ main ol li::marker {
 }
 
 .bg-footer a {
-    color: var(--footer-link, var(--color-link));
+    color: var(--footer-link, var(--link));
 }
 
 .bg-footer a:hover {
-    color: var(--footer-link-hover, var(--color-link-hover));
+    color: var(--footer-link-hover, var(--link-hover));
 }
 
 .bg-dark {
@@ -1161,7 +1169,7 @@ main ol li::marker {
 }
 
 .bg-dark a {
-    color: var(--color-link-light);
+    color: var(--link-active);
 }
 
 
@@ -1571,7 +1579,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-newsletter input[type=submit] {
-    background: var(--color-link);
+    background: var(--link);
     border: 0;
     width: 35%;
     padding: 6px 0;
@@ -1584,7 +1592,7 @@ footer h3 {
 }
 
 #footer .footer-top .footer-newsletter input[type=submit]:hover {
-    background: var(--color-link-hover)
+    background: var(--link-hover)
 }
 
 #footer .copyright {


### PR DESCRIPTION
## Summary
- add `link_default`, `link_hover`, `link_active`, and `link_visited` customizer settings with new CSS vars
- update styles and templates to use `--link` variants
- expand link state rules for `a`, `a:hover`, `a:focus`, and `a:visited`

## Testing
- `php -l inc/customizer-options.php`
- `php -l inc/customizer-dynamic-styles.php`
- `php -l inc/enqueues.php`
- `npm run lint:js` *(fails: wp-scripts not found)*
- `npm run lint:scss` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c13e524d5483308ad8f12a9be8c309