### PR TITLE
feat: add customizable border and selection colors

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -22,6 +22,10 @@ body {
   color: var(--text-base);
 }
 
+::selection {
+  background-color: var(--selection-bg);
+}
+
 small {
   color: var(--text-muted);
 }
@@ -99,11 +103,17 @@ em {
 }
 
 .sidebar-border-bot {
-  border-bottom: 2px solid var(--color-border);
+  border-bottom: 2px solid var(--border);
 }
 
 .sidebar-border {
-  border: 2px solid var(--color-border);
+  border: 2px solid var(--border);
+}
+
+#toc_container a,
+#ez-toc-container a,
+#secondary a {
+  color: var(--toc-link);
 }
 
 /*--------------------------------------------------------------
@@ -173,7 +183,7 @@ em {
 }
 
 .svg-icon svg {
-  fill: var(--accent-secondary-dark);
+  fill: var(--icon);
 }
 
 #topBar .svg-icon svg {

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -70,6 +70,9 @@ function smile_web_add_dynamic_styles() {
 		$footer_social_icon_hover = sanitize_hex_color( get_theme_mod( 'footer_social_icon_hover', '#4a994f' ) );
 $color_white                  = sanitize_hex_color( '#FFFFFF' );
 $border_color                 = sanitize_hex_color( get_theme_mod( 'border_color', '#dee2e6' ) );
+$selection_bg                 = sanitize_hex_color( get_theme_mod( 'selection_bg', '#306a93' ) );
+$icon_color                   = sanitize_hex_color( get_theme_mod( 'icon_color', '#001833' ) );
+$toc_link                     = sanitize_hex_color( get_theme_mod( 'toc_link', '#307C03' ) );
 $modal_border                 = sanitize_hex_color( '#888888' );
 
         $dynamic_css = '
@@ -134,10 +137,13 @@ $modal_border                 = sanitize_hex_color( '#888888' );
                         --footer-social-bg: ' . esc_attr( $footer_social_bg ) . ';
                         --footer-social-icon: ' . esc_attr( $footer_social_icon ) . ';
                        --footer-social-icon-hover: ' . esc_attr( $footer_social_icon_hover ) . ';
-                        --border-color: ' . esc_attr( $border_color ) . ';
+                        --border: ' . esc_attr( $border_color ) . ';
+                        --selection-bg: ' . esc_attr( $selection_bg ) . ';
+                        --icon: ' . esc_attr( $icon_color ) . ';
+                        --toc-link: ' . esc_attr( $toc_link ) . ';
                         --modal-border: ' . esc_attr( $modal_border ) . ';
-		}
-	';
+                }
+        ';
 
 	// Se agrega el CSS en línea al handle 'smile-web-main'.
 	wp_add_inline_style( 'smile-web-main', $dynamic_css );

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -330,6 +330,18 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
                                 'default' => '#dee2e6',
                                 'label'   => esc_html__( 'Border Color', 'smile-web' ),
                         ),
+                       'selection_bg'         => array(
+                               'default' => '#306a93',
+                               'label'   => esc_html__( 'Selection Background Color', 'smile-web' ),
+                       ),
+                       'icon_color'           => array(
+                               'default' => '#001833',
+                               'label'   => esc_html__( 'Icon Color', 'smile-web' ),
+                       ),
+                       'toc_link'             => array(
+                               'default' => '#307C03',
+                               'label'   => esc_html__( 'Table of Contents Link Color', 'smile-web' ),
+                       ),
 );
 
 		// Top bar color controls.

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -119,6 +119,10 @@ body {
     color: var(--text-base);
 }
 
+::selection {
+    background-color: var(--selection-bg);
+}
+
 
 
 /*--------------------------------------------------------------
@@ -344,7 +348,7 @@ a:visited {
 }
 
 .svg-icon svg {
-    fill: var(--accent-secondary-dark);
+    fill: var(--icon);
     width: 25px;
     height: 25px;
 }
@@ -1085,7 +1089,7 @@ main ol li::marker {
 }
 
 .border {
-    border: 1px solid var(--border-color) !important;
+    border: 1px solid var(--border) !important;
 }
 
 .text-emphasis {
@@ -1366,7 +1370,7 @@ section {
 --------------------------------------------------------------*/
 
 body.single .svg-icon svg {
-    fill: var(--accent-secondary-dark);
+    fill: var(--icon);
     position: relative;
 }
 
@@ -1429,6 +1433,12 @@ body.single .comment-count {
 
 .sidebar-border {
     border: 2px solid var(--accent-primary-light);
+}
+
+#toc_container a,
+#ez-toc-container a,
+#secondary a {
+    color: var(--toc-link);
 }
 
 /* BARRA LATERAL SIMULANDO HR  */
@@ -2064,47 +2074,47 @@ footer h3 {
 
 /* BORDER */
 .border-top {
-    border-top: 1px solid var(--border-color) !important;
+    border-top: 1px solid var(--border) !important;
 }
 
 .border-bottom {
-    border-bottom: 1px solid var(--border-color) !important;
+    border-bottom: 1px solid var(--border) !important;
 }
 
 .border-3 {
-    border: 3px solid var(--border-color) !important;
+    border: 3px solid var(--border) !important;
 }
 
 .border-5 {
-    border: 5px solid var(--border-color) !important;
+    border: 5px solid var(--border) !important;
 }
 
 .border-10 {
-    border: 10px solid var(--border-color) !important;
+    border: 10px solid var(--border) !important;
 }
 
 .border-15 {
-    border: 15px solid var(--border-color) !important;
+    border: 15px solid var(--border) !important;
 }
 
 .border-20 {
-    border: 20px solid var(--border-color) !important;
+    border: 20px solid var(--border) !important;
 }
 
 .border-25 {
-    border: 25px solid var(--border-color) !important;
+    border: 25px solid var(--border) !important;
 }
 
 .border-30 {
-    border: 30px solid var(--border-color) !important;
+    border: 30px solid var(--border) !important;
 }
 
 .border-35 {
-    border: 35px solid var(--border-color) !important;
+    border: 35px solid var(--border) !important;
 }
 
 .border-40 {
-    border: 40px solid var(--border-color) !important;
+    border: 40px solid var(--border) !important;
 }
 
 /* ROUNDED */

--- a/style.css
+++ b/style.css
@@ -119,6 +119,10 @@ body {
     color: var(--text-base);
 }
 
+::selection {
+    background-color: var(--selection-bg);
+}
+
 
 
 /*--------------------------------------------------------------
@@ -345,7 +349,7 @@ a:visited {
 }
 
 .svg-icon svg {
-    fill: var(--accent-secondary-dark);
+    fill: var(--icon);
     width: 25px;
     height: 25px;
 }
@@ -1086,7 +1090,7 @@ main ol li::marker {
 }
 
 .border {
-    border: 1px solid var(--border-color) !important;
+    border: 1px solid var(--border) !important;
 }
 
 .text-emphasis {
@@ -1367,7 +1371,7 @@ section {
 --------------------------------------------------------------*/
 
 body.single .svg-icon svg {
-    fill: var(--accent-secondary-dark);
+    fill: var(--icon);
     position: relative;
 }
 
@@ -1430,6 +1434,12 @@ body.single .comment-count {
 
 .sidebar-border {
     border: 2px solid var(--accent-primary-light);
+}
+
+#toc_container a,
+#ez-toc-container a,
+#secondary a {
+    color: var(--toc-link);
 }
 
 /* BARRA LATERAL SIMULANDO HR  */
@@ -2064,47 +2074,47 @@ footer h3 {
 
 /* BORDER */
 .border-top {
-    border-top: 1px solid var(--border-color) !important;
+    border-top: 1px solid var(--border) !important;
 }
 
 .border-bottom {
-    border-bottom: 1px solid var(--border-color) !important;
+    border-bottom: 1px solid var(--border) !important;
 }
 
 .border-3 {
-    border: 3px solid var(--border-color) !important;
+    border: 3px solid var(--border) !important;
 }
 
 .border-5 {
-    border: 5px solid var(--border-color) !important;
+    border: 5px solid var(--border) !important;
 }
 
 .border-10 {
-    border: 10px solid var(--border-color) !important;
+    border: 10px solid var(--border) !important;
 }
 
 .border-15 {
-    border: 15px solid var(--border-color) !important;
+    border: 15px solid var(--border) !important;
 }
 
 .border-20 {
-    border: 20px solid var(--border-color) !important;
+    border: 20px solid var(--border) !important;
 }
 
 .border-25 {
-    border: 25px solid var(--border-color) !important;
+    border: 25px solid var(--border) !important;
 }
 
 .border-30 {
-    border: 30px solid var(--border-color) !important;
+    border: 30px solid var(--border) !important;
 }
 
 .border-35 {
-    border: 35px solid var(--border-color) !important;
+    border: 35px solid var(--border) !important;
 }
 
 .border-40 {
-    border: 40px solid var(--border-color) !important;
+    border: 40px solid var(--border) !important;
 }
 
 /* ROUNDED */


### PR DESCRIPTION
## Summary
- add theme options for border, selection highlight, icon and table of contents link colors
- expose new CSS variables and replace hard-coded colors in borders, icons, selections and secondary menus

## Testing
- `php -l inc/customizer-dynamic-styles.php`
- `php -l inc/customizer-options.php`
- `npm test` *(fails: Missing script "test")*
- `npm run lint:scss` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c14a3cc308833092822efb4be56121