### PR TITLE
Use footer hover color for current page links

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -376,6 +376,10 @@ em {
   color: var(--masthead-link-hover);
 }
 
+#nav-menu .current_page_item > a {
+  color: var(--footer-link-hover);
+}
+
 .menu-item-has-children i::after {
   color: var(--masthead-submenu-text);
 }

--- a/style.css
+++ b/style.css
@@ -605,9 +605,13 @@ ul .sub-menu {
                 background-color: var(--masthead-bg);
         }
 
-	.menu-item-has-children {
-		display: block;
-		padding: 0 15px 0 0 !important;
+        #nav-menu .current_page_item > a {
+                color: var(--footer-link-hover);
+        }
+
+        .menu-item-has-children {
+display: block;
+padding: 0 15px 0 0 !important;
 	}
 
 


### PR DESCRIPTION
## Summary
- Highlight current menu item links using `var(--footer-link-hover)` instead of `--masthead-link-hover`.
- Ensure active link styles avoid `!important` for easier overrides.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c27796ac3083308699dac93ddf331e