### PR TITLE
Add breadcrumb background color setting

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -18,7 +18,7 @@ get_header();
 			<!-- Breadcrumbs -->
 			<div id="breadcrumbs" class="col-12">
 				<nav aria-label="breadcrumb">
-                                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb bg-primary">
+                                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
 						<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 														<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>">
 								<span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span>

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -30,8 +30,9 @@ function smile_web_add_dynamic_styles() {
 		$accent_secondary            = sanitize_hex_color( get_theme_mod( 'accent-secondary', '#225274' ) );
 		$accent_secondary_dark       = sanitize_hex_color( get_theme_mod( 'accent-secondary-dark', '#001833' ) );
 				$bg_primary          = sanitize_hex_color( get_theme_mod( 'bg_primary', '#edf7ef' ) );
-				$bg_secondary        = sanitize_hex_color( get_theme_mod( 'bg_secondary', '#f8f9fa' ) );
-				$button_text         = sanitize_hex_color( get_theme_mod( 'button_text', '#FFFFFF' ) );
+                               $bg_secondary        = sanitize_hex_color( get_theme_mod( 'bg_secondary', '#f8f9fa' ) );
+                               $breadcrumb_bg       = sanitize_hex_color( get_theme_mod( 'breadcrumb_bg_color', '#edf7ef' ) );
+                               $button_text         = sanitize_hex_color( get_theme_mod( 'button_text', '#FFFFFF' ) );
 				$button_text_hover   = sanitize_hex_color( get_theme_mod( 'button_text_hover', '#307C03' ) );
 				$button_bg           = sanitize_hex_color( get_theme_mod( 'button_bg', '#307C03' ) );
 				$button_bg_hover     = sanitize_hex_color( get_theme_mod( 'button_bg_hover', '#FFFFFF' ) );
@@ -97,10 +98,11 @@ function smile_web_add_dynamic_styles() {
                        --accent-primary: ' . esc_attr( $accent_primary ) . ';
                        --accent-secondary: ' . esc_attr( $accent_secondary ) . ';
                        --accent-secondary-dark: ' . esc_attr( $accent_secondary_dark ) . ';
-                        --color-white: ' . esc_attr( $color_white ) . ';
-                       --bg-primary: ' . esc_attr( $bg_primary ) . ';
-                       --bg-secondary: ' . esc_attr( $bg_secondary ) . ';
-                       --btn-text: ' . esc_attr( $button_text ) . ';
+                       --color-white: ' . esc_attr( $color_white ) . ';
+                      --bg-primary: ' . esc_attr( $bg_primary ) . ';
+                      --bg-secondary: ' . esc_attr( $bg_secondary ) . ';
+                      --breadcrumb-bg: ' . esc_attr( $breadcrumb_bg ) . ';
+                      --btn-text: ' . esc_attr( $button_text ) . ';
                        --btn-text-hover: ' . esc_attr( $button_text_hover ) . ';
                        --btn-bg: ' . esc_attr( $button_bg ) . ';
                        --btn-bg-hover: ' . esc_attr( $button_bg_hover ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -298,24 +298,28 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 		);
 
 		// Background color controls.
-		$background_colors = array(
-			'cta_bg'       => array(
-				'default' => '#ffc107',
-				'label'   => esc_html__( 'CTA Background Color', 'smile-web' ),
-			),
-			'bg_primary'   => array(
-				'default' => '#edf7ef',
-				'label'   => esc_html__( 'Primary Background Color', 'smile-web' ),
-			),
-			'bg_secondary' => array(
-				'default' => '#f8f9fa',
-				'label'   => esc_html__( 'Secondary Background Color', 'smile-web' ),
-			),
-			'selection_bg' => array(
-				'default' => '#306a93',
-				'label'   => esc_html__( 'Selection Background Color', 'smile-web' ),
-			),
-		);
+                $background_colors = array(
+                        'cta_bg'       => array(
+                                'default' => '#ffc107',
+                                'label'   => esc_html__( 'CTA Background Color', 'smile-web' ),
+                        ),
+                        'bg_primary'   => array(
+                                'default' => '#edf7ef',
+                                'label'   => esc_html__( 'Primary Background Color', 'smile-web' ),
+                        ),
+                        'bg_secondary' => array(
+                                'default' => '#f8f9fa',
+                                'label'   => esc_html__( 'Secondary Background Color', 'smile-web' ),
+                        ),
+                       'breadcrumb_bg_color' => array(
+                               'default' => '#edf7ef',
+                               'label'   => esc_html__( 'Breadcrumb Background Color', 'smile-web' ),
+                       ),
+                        'selection_bg' => array(
+                                'default' => '#306a93',
+                                'label'   => esc_html__( 'Selection Background Color', 'smile-web' ),
+                        ),
+                );
 
 		// Button color controls.
 		$button_colors = array(

--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@ $page_slug  = ( false !== $page_for_posts_id ) ? get_post_field( 'post_name', $p
 		<div class="container">
 			<div id="breadcrumbs">
 				<nav aria-label="<?php esc_attr_e( 'breadcrumb', 'smile-web' ); ?>">
-                                        <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb bg-primary">
+                                        <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
 						<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 							<img class="mx-2"
 								src="<?php echo esc_url( get_template_directory_uri() . '/lib/fontawesome-free/svgs/solid/home.svg' ); ?>"

--- a/page-fullwidth.php
+++ b/page-fullwidth.php
@@ -21,7 +21,7 @@ get_header();
 	<div class="container">
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
-                                <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb bg-primary">
+                                <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
 										<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a><meta itemprop="position" content="1" />
 					</li>
 					<?php if ( $post->post_parent ) { ?>

--- a/page-sidebar.php
+++ b/page-sidebar.php
@@ -13,7 +13,7 @@ get_header();
 		<div class="row">
 			<div id="breadcrumbs">
 				<nav aria-label="breadcrumb">
-                                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb bg-secondary">
+                                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
 												<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 							<meta itemprop="position" content="1" />
 						</li>

--- a/page.php
+++ b/page.php
@@ -46,7 +46,7 @@ get_header();
 	<div class="container py-2">
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
-                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb bg-primary">
+                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
 										<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 						<meta itemprop="position" content="1">
 					</li>

--- a/search.php
+++ b/search.php
@@ -21,7 +21,7 @@ get_header();
 	<div class="container">
 		<div id="breadcrumbs" class="pb-4">
 			<nav aria-label="breadcrumb">
-                             <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb bg-primary">
+                             <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
                                         <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name">
 					<?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 						<meta itemprop="position" content="1" />

--- a/single.php
+++ b/single.php
@@ -94,7 +94,7 @@ get_header();
 	<div class="container py-4">
 		<div id="breadcrumbs">
 			<nav aria-label="breadcrumb">
-                                <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb bg-primary">
+                                <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
 					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 						<img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/solid/home.svg" alt="home" title="<?php esc_attr_e( 'Home', 'smile-web' ); ?>
 						" width="20px" height="20px">


### PR DESCRIPTION
## Summary
- add `breadcrumb_bg_color` customizer option and expose as CSS variable `--breadcrumb-bg`
- remove `bg-primary` classes from breadcrumb markup and apply `background-color: var(--breadcrumb-bg);`

## Testing
- `for file in inc/customizer-options.php inc/customizer-dynamic-styles.php archive.php index.php page.php page-sidebar.php search.php page-fullwidth.php single.php; do php -l $file; done`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:js` *(fails: wp-scripts: not found)*
- `npm run lint:scss` *(fails: wp-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c27e07a1d48330b3c7039af1b26dd4