### PR TITLE
Add customizable front page intro colors

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -26,10 +26,13 @@ function smile_web_add_dynamic_styles() {
 		$text_quote                  = sanitize_hex_color( get_theme_mod( 'text_quote', '#225274' ) );
 		$text_list                   = sanitize_hex_color( get_theme_mod( 'text_list', '#00112b' ) );
 		$accent_primary_light        = sanitize_hex_color( get_theme_mod( 'accent-primary-light', '#d2e1ef' ) );
-		$accent_primary              = sanitize_hex_color( get_theme_mod( 'accent-primary', '#d2e1ef' ) );
-		$accent_secondary            = sanitize_hex_color( get_theme_mod( 'accent-secondary', '#225274' ) );
-		$accent_secondary_dark       = sanitize_hex_color( get_theme_mod( 'accent-secondary-dark', '#001833' ) );
-				$bg_primary          = sanitize_hex_color( get_theme_mod( 'bg_primary', '#edf7ef' ) );
+                $accent_primary              = sanitize_hex_color( get_theme_mod( 'accent-primary', '#d2e1ef' ) );
+                $accent_secondary            = sanitize_hex_color( get_theme_mod( 'accent-secondary', '#225274' ) );
+                $accent_secondary_dark       = sanitize_hex_color( get_theme_mod( 'accent-secondary-dark', '#001833' ) );
+               $front_intro_overlay         = sanitize_hex_color( get_theme_mod( 'front_intro_overlay', '#001833' ) );
+               $front_intro_heading         = sanitize_hex_color( get_theme_mod( 'front_intro_heading', '#d2e1ef' ) );
+               $front_intro_text            = sanitize_hex_color( get_theme_mod( 'front_intro_text', '#FFFFFF' ) );
+                                $bg_primary          = sanitize_hex_color( get_theme_mod( 'bg_primary', '#edf7ef' ) );
                                $bg_secondary        = sanitize_hex_color( get_theme_mod( 'bg_secondary', '#f8f9fa' ) );
                                $breadcrumb_bg       = sanitize_hex_color( get_theme_mod( 'breadcrumb_bg_color', '#edf7ef' ) );
                                $button_text         = sanitize_hex_color( get_theme_mod( 'button_text', '#FFFFFF' ) );
@@ -102,6 +105,9 @@ function smile_web_add_dynamic_styles() {
                       --bg-primary: ' . esc_attr( $bg_primary ) . ';
                       --bg-secondary: ' . esc_attr( $bg_secondary ) . ';
                       --breadcrumb-bg: ' . esc_attr( $breadcrumb_bg ) . ';
+                      --front-intro-overlay: ' . esc_attr( $front_intro_overlay ) . ';
+                      --front-intro-heading: ' . esc_attr( $front_intro_heading ) . ';
+                      --front-intro-text: ' . esc_attr( $front_intro_text ) . ';
                       --btn-text: ' . esc_attr( $button_text ) . ';
                        --btn-text-hover: ' . esc_attr( $button_text_hover ) . ';
                        --btn-bg: ' . esc_attr( $button_bg ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -90,21 +90,32 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 		)
 	);
 
-	// Add Extra Colors subsection.
-	$wp_customize->add_section(
-		'custom_theme_extra_colors',
-		array(
-			'title'      => esc_html__( 'Extra Colors', 'smile-web' ),
-			'priority'   => 16,
-			'capability' => 'edit_theme_options',
-			'panel'      => 'custom_theme_colors_panel',
-		)
-	);
+        // Add Extra Colors subsection.
+        $wp_customize->add_section(
+                'custom_theme_extra_colors',
+                array(
+                        'title'      => esc_html__( 'Extra Colors', 'smile-web' ),
+                        'priority'   => 16,
+                        'capability' => 'edit_theme_options',
+                        'panel'      => 'custom_theme_colors_panel',
+                )
+        );
 
-	// Add Top Bar Colors subsection.
-	$wp_customize->add_section(
-		'custom_theme_topbar_colors',
-		array(
+        // Add Front Page Intro Colors subsection.
+        $wp_customize->add_section(
+                'custom_theme_front_intro_colors',
+                array(
+                        'title'      => esc_html__( 'Front Page Intro Colors', 'smile-web' ),
+                        'priority'   => 17,
+                        'capability' => 'edit_theme_options',
+                        'panel'      => 'custom_theme_colors_panel',
+                )
+        );
+
+        // Add Top Bar Colors subsection.
+        $wp_customize->add_section(
+                'custom_theme_topbar_colors',
+                array(
 			'title'      => esc_html__( 'Top Bar Colors', 'smile-web' ),
 			'priority'   => 20,
 			'capability' => 'edit_theme_options',
@@ -402,11 +413,11 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 		);
 
 		// Extra color controls.
-		$extra_colors = array(
-			'color_muted'           => array(
-				'default' => '#6c757d',
-				'label'   => esc_html__( 'Muted Color', 'smile-web' ),
-			),
+                $extra_colors = array(
+                        'color_muted'           => array(
+                                'default' => '#6c757d',
+                                'label'   => esc_html__( 'Muted Color', 'smile-web' ),
+                        ),
 			'color_warning'         => array(
 				'default' => '#ffc107',
 				'label'   => esc_html__( 'Warning Color', 'smile-web' ),
@@ -431,16 +442,32 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 				'default' => '#dee2e6',
 				'label'   => esc_html__( 'Border Color', 'smile-web' ),
 			),
-			'icon_color'            => array(
-				'default' => '#001833',
-				'label'   => esc_html__( 'Icon Color', 'smile-web' ),
-			),
-		);
+                        'icon_color'            => array(
+                                'default' => '#001833',
+                                'label'   => esc_html__( 'Icon Color', 'smile-web' ),
+                        ),
+                );
 
-		// Top bar color controls.
-		$topbar_colors = array(
-			'topbar_bg'          => array(
-				'default' => '#f8f9fa',
+                // Front page intro color controls.
+                $front_intro_colors = array(
+                        'front_intro_overlay' => array(
+                                'default' => '#001833',
+                                'label'   => esc_html__( 'Intro Overlay Color', 'smile-web' ),
+                        ),
+                        'front_intro_heading' => array(
+                                'default' => '#d2e1ef',
+                                'label'   => esc_html__( 'Intro Heading Color', 'smile-web' ),
+                        ),
+                        'front_intro_text'    => array(
+                                'default' => '#FFFFFF',
+                                'label'   => esc_html__( 'Intro Text Color', 'smile-web' ),
+                        ),
+                );
+
+                // Top bar color controls.
+                $topbar_colors = array(
+                        'topbar_bg'          => array(
+                                'default' => '#f8f9fa',
 				'label'   => esc_html__( 'Top Bar Background Color', 'smile-web' ),
 			),
 			'topbar_text'        => array(
@@ -657,32 +684,54 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 					);
 				}
 
-				// Create settings and controls for extra colors.
-				foreach ( $extra_colors as $id => $args ) {
-					$wp_customize->add_setting(
-						$id,
-						array(
-							'default'           => $args['default'],
-							'sanitize_callback' => 'sanitize_hex_color',
-						)
-					);
-					$wp_customize->add_control(
-						new WP_Customize_Color_Control(
-							$wp_customize,
-							$id,
-							array(
-								'label'    => $args['label'],
-								'section'  => 'custom_theme_extra_colors',
-								'settings' => $id,
-							)
-						)
-					);
-				}
+                                // Create settings and controls for extra colors.
+                                foreach ( $extra_colors as $id => $args ) {
+                                        $wp_customize->add_setting(
+                                                $id,
+                                                array(
+                                                        'default'           => $args['default'],
+                                                        'sanitize_callback' => 'sanitize_hex_color',
+                                                )
+                                        );
+                                        $wp_customize->add_control(
+                                                new WP_Customize_Color_Control(
+                                                        $wp_customize,
+                                                        $id,
+                                                        array(
+                                                                'label'    => $args['label'],
+                                                                'section'  => 'custom_theme_extra_colors',
+                                                                'settings' => $id,
+                                                        )
+                                                )
+                                        );
+                                }
 
-				// Create settings and controls for top bar colors.
-				foreach ( $topbar_colors as $id => $args ) {
-						$wp_customize->add_setting(
-							$id,
+                                // Create settings and controls for front page intro colors.
+                                foreach ( $front_intro_colors as $id => $args ) {
+                                        $wp_customize->add_setting(
+                                                $id,
+                                                array(
+                                                        'default'           => $args['default'],
+                                                        'sanitize_callback' => 'sanitize_hex_color',
+                                                )
+                                        );
+                                        $wp_customize->add_control(
+                                                new WP_Customize_Color_Control(
+                                                        $wp_customize,
+                                                        $id,
+                                                        array(
+                                                                'label'    => $args['label'],
+                                                                'section'  => 'custom_theme_front_intro_colors',
+                                                                'settings' => $id,
+                                                        )
+                                                )
+                                        );
+                                }
+
+                                // Create settings and controls for top bar colors.
+                                foreach ( $topbar_colors as $id => $args ) {
+                                                $wp_customize->add_setting(
+                                                        $id,
 							array(
 								'default'           => $args['default'],
 								'sanitize_callback' => 'sanitize_hex_color',

--- a/style.css
+++ b/style.css
@@ -736,14 +736,27 @@ main figure {
 main figure img,
 .search-items img,
 .post-thumbnail img {
-	width: 100%;
-	height: auto;
+        width: 100%;
+        height: auto;
+}
+
+/* Front Page Intro */
+#intro::before {
+        background-color: var(--front-intro-overlay);
+}
+
+#intro h1 {
+        color: var(--front-intro-heading);
+}
+
+#intro p {
+        color: var(--front-intro-text);
 }
 
 /* # 4.1 - COLUMNS */
 .row {
-	display: flex;
-	flex-wrap: wrap;
+        display: flex;
+        flex-wrap: wrap;
 	margin: 10px 0;
 }
 


### PR DESCRIPTION
## Summary
- add "Front Page Intro Colors" Customizer subsection with overlay, heading, and text color controls
- expose front intro colors as CSS variables
- apply front intro color variables in `style.css`

## Testing
- `php -l inc/customizer-options.php`
- `php -l inc/customizer-dynamic-styles.php`
- `npx stylelint style.css` *(fails: No configuration provided for /workspace/smile-web/style.css)*

------
https://chatgpt.com/codex/tasks/task_e_68c281aecfb88330b0c71c6f4f158316