### PR TITLE
Add customizable intro colors for pages and posts

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -32,6 +32,10 @@ function smile_web_add_dynamic_styles() {
                $front_intro_overlay         = sanitize_hex_color( get_theme_mod( 'front_intro_overlay', '#001833' ) );
                $front_intro_heading         = sanitize_hex_color( get_theme_mod( 'front_intro_heading', '#d2e1ef' ) );
                $front_intro_text            = sanitize_hex_color( get_theme_mod( 'front_intro_text', '#FFFFFF' ) );
+               $page_intro_bg               = sanitize_hex_color( get_theme_mod( 'page_intro_bg', '#001833' ) );
+               $page_intro_heading          = sanitize_hex_color( get_theme_mod( 'page_intro_heading', '#d2e1ef' ) );
+               $single_intro_bg             = sanitize_hex_color( get_theme_mod( 'single_intro_bg', '#001833' ) );
+               $single_intro_heading        = sanitize_hex_color( get_theme_mod( 'single_intro_heading', '#d2e1ef' ) );
                                 $bg_primary          = sanitize_hex_color( get_theme_mod( 'bg_primary', '#edf7ef' ) );
                                $bg_secondary        = sanitize_hex_color( get_theme_mod( 'bg_secondary', '#f8f9fa' ) );
                                $breadcrumb_bg       = sanitize_hex_color( get_theme_mod( 'breadcrumb_bg_color', '#edf7ef' ) );
@@ -108,6 +112,10 @@ function smile_web_add_dynamic_styles() {
                       --front-intro-overlay: ' . esc_attr( $front_intro_overlay ) . ';
                       --front-intro-heading: ' . esc_attr( $front_intro_heading ) . ';
                       --front-intro-text: ' . esc_attr( $front_intro_text ) . ';
+                      --page-intro-bg: ' . esc_attr( $page_intro_bg ) . ';
+                      --page-intro-heading: ' . esc_attr( $page_intro_heading ) . ';
+                      --single-intro-bg: ' . esc_attr( $single_intro_bg ) . ';
+                      --single-intro-heading: ' . esc_attr( $single_intro_heading ) . ';
                       --btn-text: ' . esc_attr( $button_text ) . ';
                        --btn-text-hover: ' . esc_attr( $button_text_hover ) . ';
                        --btn-bg: ' . esc_attr( $button_bg ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -112,6 +112,28 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
                 )
         );
 
+       // Add Page Intro Colors subsection.
+       $wp_customize->add_section(
+               'custom_theme_page_intro_colors',
+               array(
+                       'title'      => esc_html__( 'Page Intro Colors', 'smile-web' ),
+                       'priority'   => 18,
+                       'capability' => 'edit_theme_options',
+                       'panel'      => 'custom_theme_colors_panel',
+               )
+       );
+
+       // Add Single Post Intro Colors subsection.
+       $wp_customize->add_section(
+               'custom_theme_single_intro_colors',
+               array(
+                       'title'      => esc_html__( 'Single Post Intro Colors', 'smile-web' ),
+                       'priority'   => 19,
+                       'capability' => 'edit_theme_options',
+                       'panel'      => 'custom_theme_colors_panel',
+               )
+       );
+
         // Add Top Bar Colors subsection.
         $wp_customize->add_section(
                 'custom_theme_topbar_colors',
@@ -464,6 +486,30 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
                         ),
                 );
 
+               // Page intro color controls.
+               $page_intro_colors = array(
+                       'page_intro_bg' => array(
+                               'default' => '#001833',
+                               'label'   => esc_html__( 'Intro Background Color', 'smile-web' ),
+                       ),
+                       'page_intro_heading' => array(
+                               'default' => '#d2e1ef',
+                               'label'   => esc_html__( 'Intro Heading Color', 'smile-web' ),
+                       ),
+               );
+
+               // Single post intro color controls.
+               $single_intro_colors = array(
+                       'single_intro_bg' => array(
+                               'default' => '#001833',
+                               'label'   => esc_html__( 'Intro Background Color', 'smile-web' ),
+                       ),
+                       'single_intro_heading' => array(
+                               'default' => '#d2e1ef',
+                               'label'   => esc_html__( 'Intro Heading Color', 'smile-web' ),
+                       ),
+               );
+
                 // Top bar color controls.
                 $topbar_colors = array(
                         'topbar_bg'          => array(
@@ -706,30 +752,74 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
                                         );
                                 }
 
-                                // Create settings and controls for front page intro colors.
-                                foreach ( $front_intro_colors as $id => $args ) {
-                                        $wp_customize->add_setting(
-                                                $id,
-                                                array(
-                                                        'default'           => $args['default'],
-                                                        'sanitize_callback' => 'sanitize_hex_color',
-                                                )
-                                        );
-                                        $wp_customize->add_control(
-                                                new WP_Customize_Color_Control(
-                                                        $wp_customize,
-                                                        $id,
-                                                        array(
-                                                                'label'    => $args['label'],
-                                                                'section'  => 'custom_theme_front_intro_colors',
-                                                                'settings' => $id,
-                                                        )
-                                                )
-                                        );
-                                }
+                               // Create settings and controls for front page intro colors.
+                               foreach ( $front_intro_colors as $id => $args ) {
+                                       $wp_customize->add_setting(
+                                               $id,
+                                               array(
+                                                       'default'           => $args['default'],
+                                                       'sanitize_callback' => 'sanitize_hex_color',
+                                               )
+                                       );
+                                       $wp_customize->add_control(
+                                               new WP_Customize_Color_Control(
+                                                       $wp_customize,
+                                                       $id,
+                                                       array(
+                                                               'label'    => $args['label'],
+                                                               'section'  => 'custom_theme_front_intro_colors',
+                                                               'settings' => $id,
+                                                       )
+                                               )
+                                       );
+                               }
 
-                                // Create settings and controls for top bar colors.
-                                foreach ( $topbar_colors as $id => $args ) {
+                               // Create settings and controls for page intro colors.
+                               foreach ( $page_intro_colors as $id => $args ) {
+                                       $wp_customize->add_setting(
+                                               $id,
+                                               array(
+                                                       'default'           => $args['default'],
+                                                       'sanitize_callback' => 'sanitize_hex_color',
+                                               )
+                                       );
+                                       $wp_customize->add_control(
+                                               new WP_Customize_Color_Control(
+                                                       $wp_customize,
+                                                       $id,
+                                                       array(
+                                                               'label'    => $args['label'],
+                                                               'section'  => 'custom_theme_page_intro_colors',
+                                                               'settings' => $id,
+                                                       )
+                                               )
+                                       );
+                               }
+
+                               // Create settings and controls for single post intro colors.
+                               foreach ( $single_intro_colors as $id => $args ) {
+                                       $wp_customize->add_setting(
+                                               $id,
+                                               array(
+                                                       'default'           => $args['default'],
+                                                       'sanitize_callback' => 'sanitize_hex_color',
+                                               )
+                                       );
+                                       $wp_customize->add_control(
+                                               new WP_Customize_Color_Control(
+                                                       $wp_customize,
+                                                       $id,
+                                                       array(
+                                                               'label'    => $args['label'],
+                                                               'section'  => 'custom_theme_single_intro_colors',
+                                                               'settings' => $id,
+                                                       )
+                                               )
+                                       );
+                               }
+
+                               // Create settings and controls for top bar colors.
+                               foreach ( $topbar_colors as $id => $args ) {
                                                 $wp_customize->add_setting(
                                                         $id,
 							array(

--- a/inc/enqueues.php
+++ b/inc/enqueues.php
@@ -244,9 +244,9 @@ function smile_v6_enqueue_scripts() {
 }
 		';
 	} elseif ( is_page() ) {
-		$dynamic_css .= '
+               $dynamic_css .= '
 #intro {
-        background-color: var(--accent-secondary-dark);
+        background-color: var(--page-intro-bg);
     color: var(--color-white);
     position: relative;
     z-index: 0;
@@ -254,7 +254,7 @@ function smile_v6_enqueue_scripts() {
     min-height: 300px;
 }
     #intro h1 {
-    color: var(--accent-primary-light);
+    color: var(--page-intro-heading);
     width: 100%;
 }
 .entry-header {
@@ -297,7 +297,7 @@ function smile_v6_enqueue_scripts() {
         height: 100%;
         margin: 0;
         overflow: hidden;
-        background-color: var(--accent-secondary-dark);
+        background-color: var(--page-intro-bg);
     }
     #intro-carousel img {
         width: 100%;
@@ -318,16 +318,16 @@ function smile_v6_enqueue_scripts() {
 }
 		';
 	} else {
-		$dynamic_css .= '
+               $dynamic_css .= '
 #intro {
-    background-color: var(--accent-secondary-dark);
+    background-color: var(--single-intro-bg);
     color: var(--color-white);
     position: relative;
     z-index: 0;
     margin-bottom: -10px;
 }
     #intro h1 {
-    color: var(--accent-primary-light);
+    color: var(--single-intro-heading);
     width: 100%;
 }
 .entry-header {

--- a/page.php
+++ b/page.php
@@ -12,7 +12,7 @@
 
 get_header();
 ?>
-<div id="intro" class="pt-5" style="background-color: var(--cta-bg);">
+<div id="intro" class="pt-5" style="background-color: var(--page-intro-bg);">
 	<div class="container py-5 text-center">
 		<h1 class="title mt-2"><?php the_title(); ?></h1>
 		<a href="#main" class="btn-cta" rel="nofollow noopener" aria-label="<?php esc_attr_e( 'Go to main content', 'smile-web' ); ?>">

--- a/single.php
+++ b/single.php
@@ -9,7 +9,7 @@
 
 get_header();
 ?>
-<div id="intro" class="pt-5">
+<div id="intro" class="pt-5" style="background-color: var(--single-intro-bg);">
 	<div class="container py-3">
 		<div class="row text-center py-2">
                         <h1 class="text-heading my-2"><?php the_title(); ?></h1>

--- a/style.css
+++ b/style.css
@@ -741,16 +741,34 @@ main figure img,
 }
 
 /* Front Page Intro */
-#intro::before {
+.home #intro::before {
         background-color: var(--front-intro-overlay);
 }
 
-#intro h1 {
+.home #intro h1 {
         color: var(--front-intro-heading);
 }
 
-#intro p {
+.home #intro p {
         color: var(--front-intro-text);
+}
+
+/* Page Intro */
+.page #intro {
+        background-color: var(--page-intro-bg);
+}
+
+.page #intro h1 {
+        color: var(--page-intro-heading);
+}
+
+/* Single Post Intro */
+.single-post #intro {
+        background-color: var(--single-intro-bg);
+}
+
+.single-post #intro h1 {
+        color: var(--single-intro-heading);
 }
 
 /* # 4.1 - COLUMNS */


### PR DESCRIPTION
## Summary
- allow custom intro background and heading colors for pages and single posts
- expose new intro color variables in dynamic styles and templates
- restrict intro overlay to front page only

## Testing
- `php -l inc/customizer-dynamic-styles.php`
- `php -l inc/customizer-options.php`
- `php -l inc/enqueues.php`
- `php -l page.php`
- `php -l single.php`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c285085ef083309d4251a2dcf05906