### PR TITLE
Add alpha slider for intro overlay

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -29,7 +29,11 @@ function smile_web_add_dynamic_styles() {
                 $accent_primary              = sanitize_hex_color( get_theme_mod( 'accent-primary', '#d2e1ef' ) );
                 $accent_secondary            = sanitize_hex_color( get_theme_mod( 'accent-secondary', '#225274' ) );
                 $accent_secondary_dark       = sanitize_hex_color( get_theme_mod( 'accent-secondary-dark', '#001833' ) );
-               $front_intro_overlay         = sanitize_hex_color( get_theme_mod( 'front_intro_overlay', '#001833' ) );
+               $front_intro_overlay_color   = sanitize_hex_color( get_theme_mod( 'front_intro_overlay', '#001833' ) );
+               $front_intro_overlay_alpha   = floatval( get_theme_mod( 'front_intro_overlay_alpha', 0.8 ) );
+               $front_intro_overlay_alpha   = min( 1, max( 0, $front_intro_overlay_alpha ) );
+               list( $fio_r, $fio_g, $fio_b ) = sscanf( $front_intro_overlay_color, '#%02x%02x%02x' );
+               $front_intro_overlay         = sprintf( 'rgba(%d,%d,%d,%s)', $fio_r, $fio_g, $fio_b, $front_intro_overlay_alpha );
                $front_intro_heading         = sanitize_hex_color( get_theme_mod( 'front_intro_heading', '#d2e1ef' ) );
                $front_intro_text            = sanitize_hex_color( get_theme_mod( 'front_intro_text', '#FFFFFF' ) );
                $page_intro_bg               = sanitize_hex_color( get_theme_mod( 'page_intro_bg', '#001833' ) );

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -6,6 +6,28 @@
  */
 
 /**
+ * Sanitize opacity values for rgba colors.
+ *
+ * Ensures the value is a float between 0 and 1.
+ *
+ * @param mixed $value Opacity value.
+ * @return float Sanitized opacity.
+ */
+function smile_web_sanitize_alpha( $value ) {
+       $value = floatval( $value );
+
+       if ( $value < 0 ) {
+               $value = 0;
+       }
+
+       if ( $value > 1 ) {
+               $value = 1;
+       }
+
+       return $value;
+}
+
+/**
  * Registers customizer sections, settings and controls.
  *
  * @param WP_Customize_Manager $wp_customize Customizer instance.
@@ -470,21 +492,60 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
                         ),
                 );
 
-                // Front page intro color controls.
-                $front_intro_colors = array(
-                        'front_intro_overlay' => array(
-                                'default' => '#001833',
-                                'label'   => esc_html__( 'Intro Overlay Color', 'smile-web' ),
-                        ),
-                        'front_intro_heading' => array(
-                                'default' => '#d2e1ef',
-                                'label'   => esc_html__( 'Intro Heading Color', 'smile-web' ),
-                        ),
-                        'front_intro_text'    => array(
-                                'default' => '#FFFFFF',
-                                'label'   => esc_html__( 'Intro Text Color', 'smile-web' ),
-                        ),
-                );
+               // Front page intro color controls.
+
+               // Overlay color and opacity.
+               $wp_customize->add_setting(
+                       'front_intro_overlay',
+                       array(
+                               'default'           => '#001833',
+                               'sanitize_callback' => 'sanitize_hex_color',
+                       )
+               );
+
+               $wp_customize->add_control(
+                       new WP_Customize_Color_Control(
+                               $wp_customize,
+                               'front_intro_overlay',
+                               array(
+                                       'label'   => esc_html__( 'Intro Overlay Color', 'smile-web' ),
+                                       'section' => 'custom_theme_front_intro_colors',
+                               )
+                       )
+               );
+
+               $wp_customize->add_setting(
+                       'front_intro_overlay_alpha',
+                       array(
+                               'default'           => 0.8,
+                               'sanitize_callback' => 'smile_web_sanitize_alpha',
+                       )
+               );
+
+               $wp_customize->add_control(
+                       'front_intro_overlay_alpha',
+                       array(
+                               'label'       => esc_html__( 'Intro Overlay Opacity', 'smile-web' ),
+                               'section'     => 'custom_theme_front_intro_colors',
+                               'type'        => 'range',
+                               'input_attrs' => array(
+                                       'min'  => 0,
+                                       'max'  => 1,
+                                       'step' => 0.01,
+                               ),
+                       )
+               );
+
+               $front_intro_colors = array(
+                       'front_intro_heading' => array(
+                               'default' => '#d2e1ef',
+                               'label'   => esc_html__( 'Intro Heading Color', 'smile-web' ),
+                       ),
+                       'front_intro_text'    => array(
+                               'default' => '#FFFFFF',
+                               'label'   => esc_html__( 'Intro Text Color', 'smile-web' ),
+                       ),
+               );
 
                // Page intro color controls.
                $page_intro_colors = array(

--- a/style.css
+++ b/style.css
@@ -742,6 +742,7 @@ main figure img,
 
 /* Front Page Intro */
 .home #intro::before {
+        /* Overlay color with alpha from Customizer */
         background-color: var(--front-intro-overlay);
 }
 


### PR DESCRIPTION
## Summary
- add opacity sanitizer and new Customizer controls for intro overlay
- output front intro overlay as rgba custom property
- reference front intro overlay variable in front-page intro styles

## Testing
- `php -l inc/customizer-options.php`
- `php -l inc/customizer-dynamic-styles.php`
- `npm test` (fails: Missing script "test")
- `npm run compile:rtl` (fails: rtlcss: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c2a1a0dec4833087f98afe92d26f93