### PR TITLE
Increase specificity for front page intro styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -741,16 +741,16 @@ main figure img,
 }
 
 /* Front Page Intro */
-.home #intro::before {
+body.home #intro::before {
         /* Overlay color with alpha from Customizer */
         background-color: var(--front-intro-overlay);
 }
 
-.home #intro h1 {
+body.home #intro h1 {
         color: var(--front-intro-heading);
 }
 
-.home #intro p {
+body.home #intro p {
         color: var(--front-intro-text);
 }
 


### PR DESCRIPTION
## Summary
- Increase specificity of front-page intro selectors so page template styles no longer override them.
- Verified stylesheet enqueue order to ensure `assets/css/main.css` follows `style.css`.

## Testing
- `/tmp/wpcs-package/vendor/bin/phpcs --standard=WordPress style.css assets/css/main.css`


------
https://chatgpt.com/codex/tasks/task_e_68c2a33e4ce48330941ae10e18f20d87