### PR TITLE
Enable alpha page intro background

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -36,8 +36,12 @@ function smile_web_add_dynamic_styles() {
                $front_intro_overlay         = sprintf( 'rgba(%d,%d,%d,%s)', $fio_r, $fio_g, $fio_b, $front_intro_overlay_alpha );
                $front_intro_heading         = sanitize_hex_color( get_theme_mod( 'front_intro_heading', '#d2e1ef' ) );
                $front_intro_text            = sanitize_hex_color( get_theme_mod( 'front_intro_text', '#FFFFFF' ) );
-               $page_intro_bg               = sanitize_hex_color( get_theme_mod( 'page_intro_bg', '#001833' ) );
-               $page_intro_heading          = sanitize_hex_color( get_theme_mod( 'page_intro_heading', '#d2e1ef' ) );
+$page_intro_bg_color         = sanitize_hex_color( get_theme_mod( 'page_intro_bg', '#001833' ) );
+$page_intro_bg_alpha         = floatval( get_theme_mod( 'page_intro_bg_alpha', 1 ) );
+$page_intro_bg_alpha         = min( 1, max( 0, $page_intro_bg_alpha ) );
+list( $pib_r, $pib_g, $pib_b ) = sscanf( $page_intro_bg_color, '#%02x%02x%02x' );
+$page_intro_bg               = sprintf( 'rgba(%d,%d,%d,%s)', $pib_r, $pib_g, $pib_b, $page_intro_bg_alpha );
+$page_intro_heading          = sanitize_hex_color( get_theme_mod( 'page_intro_heading', '#d2e1ef' ) );
                $single_intro_bg             = sanitize_hex_color( get_theme_mod( 'single_intro_bg', '#001833' ) );
                $single_intro_heading        = sanitize_hex_color( get_theme_mod( 'single_intro_heading', '#d2e1ef' ) );
                                 $bg_primary          = sanitize_hex_color( get_theme_mod( 'bg_primary', '#edf7ef' ) );

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -546,13 +546,47 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
                                'label'   => esc_html__( 'Intro Text Color', 'smile-web' ),
                        ),
                );
+               // Page intro background color with alpha controls.
+               $wp_customize->add_setting(
+                       'page_intro_bg',
+                       array(
+                               'default'           => '#001833',
+                               'sanitize_callback' => 'sanitize_hex_color',
+                       )
+               );
+               $wp_customize->add_control(
+                       new WP_Customize_Color_Control(
+                               $wp_customize,
+                               'page_intro_bg',
+                               array(
+                                       'label'   => esc_html__( 'Intro Background Color', 'smile-web' ),
+                                       'section' => 'custom_theme_page_intro_colors',
+                               )
+                       )
+               );
+               $wp_customize->add_setting(
+                       'page_intro_bg_alpha',
+                       array(
+                               'default'           => 1,
+                               'sanitize_callback' => 'smile_web_sanitize_alpha',
+                       )
+               );
+               $wp_customize->add_control(
+                       'page_intro_bg_alpha',
+                       array(
+                               'label'       => esc_html__( 'Intro Background Opacity', 'smile-web' ),
+                               'section'     => 'custom_theme_page_intro_colors',
+                               'type'        => 'range',
+                               'input_attrs' => array(
+                                       'min'  => 0,
+                                       'max'  => 1,
+                                       'step' => 0.01,
+                               ),
+                       )
+               );
 
                // Page intro color controls.
                $page_intro_colors = array(
-                       'page_intro_bg' => array(
-                               'default' => '#001833',
-                               'label'   => esc_html__( 'Intro Background Color', 'smile-web' ),
-                       ),
                        'page_intro_heading' => array(
                                'default' => '#d2e1ef',
                                'label'   => esc_html__( 'Intro Heading Color', 'smile-web' ),

--- a/style.css
+++ b/style.css
@@ -755,7 +755,7 @@ body.home #intro p {
 }
 
 /* Page Intro */
-.page #intro {
+body.page #intro::before {
         background-color: var(--page-intro-bg);
 }
 


### PR DESCRIPTION
## Summary
- allow customizing the page intro background opacity
- output `--page-intro-bg` as an RGBA color
- style page intro overlay via `body.page #intro::before`

## Testing
- `php -l inc/customizer-options.php`
- `php -l inc/customizer-dynamic-styles.php`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c2ac0107988330ad18a92a542b7348