### PR TITLE
Fix intro overlay on front page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -385,3 +385,30 @@ em {
     color: var(--masthead-submenu-text);
   }
 }
+/* Front Page Intro */
+body.home #intro::before {
+  /* Overlay color with alpha from Customizer */
+  background-color: var(--front-intro-overlay);
+}
+
+body.home #intro h1 {
+  color: var(--front-intro-heading);
+}
+
+body.home #intro p {
+  color: var(--front-intro-text);
+}
+
+/* Page Intro */
+body.page:not(.home) #intro::before {
+  background-color: var(--page-intro-bg);
+}
+
+.page #intro h1 {
+  color: var(--page-intro-heading);
+}
+
+/* Single Post Intro */
+body.single #intro::before {
+  background-color: var(--single-intro-bg);
+}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2574,3 +2574,30 @@ footer h3 {
 .gy-5 {
 	--bs-gutter-y: 3rem
 }
+/* Front Page Intro */
+body.home #intro::before {
+	/* Overlay color with alpha from Customizer */
+	background-color: var(--front-intro-overlay);
+}
+
+body.home #intro h1 {
+	color: var(--front-intro-heading);
+}
+
+body.home #intro p {
+	color: var(--front-intro-text);
+}
+
+/* Page Intro */
+body.page:not(.home) #intro::before {
+	background-color: var(--page-intro-bg);
+}
+
+.page #intro h1 {
+	color: var(--page-intro-heading);
+}
+
+/* Single Post Intro */
+body.single #intro::before {
+	background-color: var(--single-intro-bg);
+}

--- a/style.css
+++ b/style.css
@@ -755,7 +755,7 @@ body.home #intro p {
 }
 
 /* Page Intro */
-body.page #intro::before {
+body.page:not(.home) #intro::before {
         background-color: var(--page-intro-bg);
 }
 


### PR DESCRIPTION
## Summary
- avoid applying page intro overlay to the home page by scoping selector with `:not(.home)`
- mirror intro overlay rules across rtl and compiled stylesheets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:js` *(fails: wp-scripts not found)*
- `npm install` *(fails: node-sass build error due to missing distutils)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bc7be0188330bdbe6bd676c364f1