### PR TITLE
Display and style post categories with customizer options

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -273,20 +273,26 @@ em {
 }
 
 .post-categories {
-  list-style: none;
-  padding: 0px 15px;
-  margin: 0px;
-  display: flex;
+  list-style:none;
+  margin:0;
+  padding:0;
 }
 
 .post-categories li {
-  margin-right: 5px;
+  display:inline-block;
+  margin-right:0.5rem;
 }
 
-.post-categories li a {
-  text-decoration: none;
-  color: var(--color-white);
-  padding: 0 10px;
+.post-categories a {
+  background-color: var(--category-bg);
+  color: var(--category-text);
+  padding:0.25rem 0.5rem;
+  border-radius:4px;
+}
+
+.post-categories a:hover {
+  background-color: var(--category-bg-hover);
+  color: var(--category-text-hover);
 }
 
 .blog-col {

--- a/front-page.php
+++ b/front-page.php
@@ -114,23 +114,15 @@ if ( 'yes' === $show_header_image && ! empty( $header_image ) ) {
 				while ( $recent_posts->have_posts() ) :
 					$recent_posts->the_post();
 					?>
-				<article <?php post_class( 'blog-col col-md-4 mb-4 mx-0' ); ?>>
-					<div class="category">
-						<?php
-															$categories = get_the_category();
-						if ( $categories ) {
-							foreach ( $categories as $category ) {
-																		printf(
-																			'<a href="%1$s">%2$s</a>',
-																			esc_url( get_category_link( $category->term_id ) ),
-																			esc_html( $category->name )
-																		);
-							}
-						}
-						?>
-					</div>
+                                <article <?php post_class( 'blog-col col-md-4 mb-4 mx-0' ); ?>>
+                                        <?php
+                                        $categories_list = get_the_category_list( '</li><li>' );
+                                        if ( $categories_list ) {
+                                                echo '<ul class="post-categories"><li>' . wp_kses_post( $categories_list ) . '</li></ul>';
+                                        }
+                                        ?>
 
-					<figure class="shadow">
+                                        <figure class="shadow">
 						<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
 							<?php
 							if ( has_post_thumbnail() ) {

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -91,9 +91,13 @@ $page_intro_heading          = sanitize_hex_color( get_theme_mod( 'page_intro_he
 	$color_white                     = sanitize_hex_color( '#FFFFFF' );
 	$border_color                    = sanitize_hex_color( get_theme_mod( 'border_color', '#dee2e6' ) );
 	$selection_bg                    = sanitize_hex_color( get_theme_mod( 'selection_bg', '#306a93' ) );
-	$icon_color                      = sanitize_hex_color( get_theme_mod( 'icon_color', '#001833' ) );
-	$toc_link                        = sanitize_hex_color( get_theme_mod( 'toc_link', '#307C03' ) );
-	$modal_border                    = sanitize_hex_color( '#888888' );
+        $icon_color                      = sanitize_hex_color( get_theme_mod( 'icon_color', '#001833' ) );
+        $toc_link                        = sanitize_hex_color( get_theme_mod( 'toc_link', '#307C03' ) );
+        $category_bg                     = sanitize_hex_color( get_theme_mod( 'category_bg', '#307C03' ) );
+        $category_bg_hover               = sanitize_hex_color( get_theme_mod( 'category_bg_hover', '#306a93' ) );
+        $category_text                   = sanitize_hex_color( get_theme_mod( 'category_text', '#FFFFFF' ) );
+        $category_text_hover             = sanitize_hex_color( get_theme_mod( 'category_text_hover', '#FFFFFF' ) );
+        $modal_border                    = sanitize_hex_color( '#888888' );
 
 		$dynamic_css = '
                 :root {
@@ -168,6 +172,10 @@ $page_intro_heading          = sanitize_hex_color( get_theme_mod( 'page_intro_he
                         --border: ' . esc_attr( $border_color ) . ';
                         --selection-bg: ' . esc_attr( $selection_bg ) . ';
                         --icon: ' . esc_attr( $icon_color ) . ';
+                        --category-bg: ' . esc_attr( $category_bg ) . ';
+                        --category-bg-hover: ' . esc_attr( $category_bg_hover ) . ';
+                        --category-text: ' . esc_attr( $category_text ) . ';
+                        --category-text-hover: ' . esc_attr( $category_text_hover ) . ';
                         --toc-link: ' . esc_attr( $toc_link ) . ';
                         --modal-border: ' . esc_attr( $modal_border ) . ';
                 }

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -490,6 +490,22 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
                                 'default' => '#001833',
                                 'label'   => esc_html__( 'Icon Color', 'smile-web' ),
                         ),
+                        'category_bg'           => array(
+                                'default' => '#307C03',
+                                'label'   => esc_html__( 'Category Background Color', 'smile-web' ),
+                        ),
+                        'category_bg_hover'     => array(
+                                'default' => '#306a93',
+                                'label'   => esc_html__( 'Category Background Hover Color', 'smile-web' ),
+                        ),
+                        'category_text'         => array(
+                                'default' => '#FFFFFF',
+                                'label'   => esc_html__( 'Category Text Color', 'smile-web' ),
+                        ),
+                        'category_text_hover'   => array(
+                                'default' => '#FFFFFF',
+                                'label'   => esc_html__( 'Category Text Hover Color', 'smile-web' ),
+                        ),
                 );
 
                // Front page intro color controls.

--- a/style.css
+++ b/style.css
@@ -1434,12 +1434,36 @@ body.single .comment-count {
 }
 
 .figcaption-text {
-	color: var(--card-text-color);
+        color: var(--card-text-color);
+}
+
+/* Post Categories */
+.post-categories {
+	list-style:none;
+	margin:0;
+	padding:0;
+}
+
+.post-categories li {
+	display:inline-block;
+	margin-right:0.5rem;
+}
+
+.post-categories a {
+	background-color: var(--category-bg);
+	color: var(--category-text);
+	padding:0.25rem 0.5rem;
+	border-radius:4px;
+}
+
+.post-categories a:hover {
+	background-color: var(--category-bg-hover);
+	color: var(--category-text-hover);
 }
 
 /* # 4.9 - SIDEBAR */
 .sidebar-menu {
-	background-color: var(--color-white);
+        background-color: var(--color-white);
 	border: 2px solid var(--accent-primary-light);
 	padding: 10px;
 }


### PR DESCRIPTION
## Summary
- Render post categories as a sanitized list on the front page
- Style post category links and add customizable color variables
- Add Customizer settings and dynamic CSS variables for category colors

## Testing
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs --standard=WordPress front-page.php style.css inc/customizer-options.php inc/customizer-dynamic-styles.php | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68c2d8a0423483308cff17cf34228689