### PR TITLE
Wrap categories and restore lead style on front page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -272,25 +272,25 @@ em {
   display: grid;
 }
 
-.post-categories {
+.category .post-categories {
   list-style:none;
   margin:0;
   padding:0;
 }
 
-.post-categories li {
+.category .post-categories li {
   display:inline-block;
   margin-right:0.5rem;
 }
 
-.post-categories a {
+.category .post-categories a {
   background-color: var(--category-bg);
   color: var(--category-text);
   padding:0.25rem 0.5rem;
   border-radius:4px;
 }
 
-.post-categories a:hover {
+.category .post-categories a:hover {
   background-color: var(--category-bg-hover);
   color: var(--category-text-hover);
 }

--- a/front-page.php
+++ b/front-page.php
@@ -47,9 +47,9 @@ if ( 'yes' === $show_header_image && ! empty( $header_image ) ) {
 		<div class="row">
 			<div class="col-md-6">
 				<?php if ( 'custom' === $intro_content_type && ! empty( $intro_custom_title ) ) : ?>
-                                <h1 class="text-heading"><?php echo esc_html( $intro_custom_title ); ?></h1>
+								<h1 class="text-heading"><?php echo esc_html( $intro_custom_title ); ?></h1>
 				<?php else : ?>
-                                <h1 class="text-heading"><?php the_title(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h1>
+								<h1 class="text-heading"><?php the_title(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h1>
 				<?php endif; ?>
 
 				<?php if ( 'custom' === $intro_content_type && ! empty( $intro_custom_description ) ) : ?>
@@ -98,12 +98,12 @@ if ( 'yes' === $show_header_image && ! empty( $header_image ) ) {
 
 	if ( $recent_posts->have_posts() ) :
 		?>
-    <section id="posts-relacionados" class="bg-secondary">
+	<section id="posts-relacionados" class="bg-secondary">
 		<div class="container py-5 text-center">
-                    <p class="text-emphasis pb-2 border-bottom">
+					<p class="text-emphasis pb-2 border-bottom">
 				<?php echo esc_html( $custom_blog_title ); ?>
 			</p>
-                    <p class="text-emphasis">
+					<p class="text-emphasis">
 				<?php echo esc_html( $blog_description ); ?>
 			</p>
 		</div>
@@ -114,15 +114,15 @@ if ( 'yes' === $show_header_image && ! empty( $header_image ) ) {
 				while ( $recent_posts->have_posts() ) :
 					$recent_posts->the_post();
 					?>
-                                <article <?php post_class( 'blog-col col-md-4 mb-4 mx-0' ); ?>>
-                                        <?php
-                                        $categories_list = get_the_category_list( '</li><li>' );
-                                        if ( $categories_list ) {
-                                                echo '<ul class="post-categories"><li>' . wp_kses_post( $categories_list ) . '</li></ul>';
-                                        }
-                                        ?>
+								<article <?php post_class( 'blog-col col-md-4 mb-4 mx-0' ); ?>>
+										<?php
+										$categories_list = get_the_category_list( '</li><li>' );
+										if ( $categories_list ) {
+												echo '<div class="category"><ul class="post-categories"><li>' . wp_kses_post( $categories_list ) . '</li></ul></div>';
+										}
+										?>
 
-                                        <figure class="shadow">
+										<figure class="shadow">
 						<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
 							<?php
 							if ( has_post_thumbnail() ) {
@@ -148,9 +148,9 @@ if ( 'yes' === $show_header_image && ! empty( $header_image ) ) {
 							?>
 						</a>
 
-						<figcaption class="bg-white px-4">
-                                                    <p class="text-emphasis">
-								<a href="<?php the_permalink(); ?>" rel="bookmark">
+												<figcaption class="bg-white px-4">
+													<p class="lead">
+																<a href="<?php the_permalink(); ?>" rel="bookmark">
 									<?php the_title(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 								</a>
 							</p>

--- a/style.css
+++ b/style.css
@@ -1438,27 +1438,27 @@ body.single .comment-count {
 }
 
 /* Post Categories */
-.post-categories {
-	list-style:none;
-	margin:0;
-	padding:0;
+.category .post-categories {
+        list-style:none;
+        margin:0;
+        padding:0;
 }
 
-.post-categories li {
-	display:inline-block;
-	margin-right:0.5rem;
+.category .post-categories li {
+        display:inline-block;
+        margin-right:0.5rem;
 }
 
-.post-categories a {
-	background-color: var(--category-bg);
-	color: var(--category-text);
-	padding:0.25rem 0.5rem;
-	border-radius:4px;
+.category .post-categories a {
+        background-color: var(--category-bg);
+        color: var(--category-text);
+        padding:0.25rem 0.5rem;
+        border-radius:4px;
 }
 
-.post-categories a:hover {
-	background-color: var(--category-bg-hover);
-	color: var(--category-text-hover);
+.category .post-categories a:hover {
+        background-color: var(--category-bg-hover);
+        color: var(--category-text-hover);
 }
 
 /* # 4.9 - SIDEBAR */


### PR DESCRIPTION
## Summary
- wrap post categories in a `.category` div within the front-page post loop
- restore `.lead` class for post titles in front-page loop
- update CSS selectors to `.category .post-categories`

## Testing
- `phpcs --standard=WordPress front-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2dd47165c83309da8ad48c2fda864