### PR TITLE
feat: adjust submenu arrow colors

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -334,6 +334,25 @@ em {
 	color: var(--masthead-link-hover);
 }
 
+.menu-item-has-children i::after {
+	content: "\003E";
+	position: absolute;
+	top: 20px;
+	right: 20px !important;
+	z-index: 9999;
+	right: 30px;
+	font-weight: 200;
+	font-size: 20px;
+}
+
+#masthead .menu-item-has-children i::after {
+	color: var(--masthead-submenu-text);
+}
+
+#footer .menu-item-has-children i::after {
+	color: var(--footer-text);
+}
+
 #nav-menu .current_page_item > a {
 	color: var(--footer-link-hover);
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -553,10 +553,17 @@ ul .sub-menu {
 	left: 20px !important;
 	z-index: 9999;
 	left: 30px;
-	color: var(--masthead-submenu-text);
 	font-weight: 200;
 	font-size: 20px;
 }
+#masthead .menu-item-has-children i::after {
+	color: var(--masthead-submenu-text);
+}
+
+#footer .menu-item-has-children i::after {
+	color: var(--footer-text);
+}
+
 
 .menu-item-has-children .child-arrow-down::after {
 	transform: rotate(-90deg);
@@ -623,10 +630,17 @@ ul .sub-menu {
 	.menu-item-has-children i::after {
 		top: 5px;
 		left: 5px !important;
-		color: var(--masthead-link);
 		font-weight: 100;
 		font-size: 15px;
 	}
+	#masthead .menu-item-has-children i::after {
+		color: var(--masthead-link);
+	}
+
+	#footer .menu-item-has-children i::after {
+		color: var(--footer-text);
+	}
+
 
 	/* focus-within */
 	#masthead .menu-item-has-children:focus-within>.sub-menu,

--- a/style.css
+++ b/style.css
@@ -553,10 +553,17 @@ ul .sub-menu {
 	right: 20px !important;
 	z-index: 9999;
 	right: 30px;
-	color: var(--masthead-submenu-text);
 	font-weight: 200;
 	font-size: 20px;
 }
+#masthead .menu-item-has-children i::after {
+	color: var(--masthead-submenu-text);
+}
+
+#footer .menu-item-has-children i::after {
+	color: var(--footer-text);
+}
+
 
 .menu-item-has-children .child-arrow-down::after {
 	transform: rotate(90deg);
@@ -623,10 +630,17 @@ ul .sub-menu {
 	.menu-item-has-children i::after {
 		top: 5px;
 		right: 5px !important;
-		color: var(--masthead-link);
 		font-weight: 100;
 		font-size: 15px;
 	}
+	#masthead .menu-item-has-children i::after {
+		color: var(--masthead-link);
+	}
+
+	#footer .menu-item-has-children i::after {
+		color: var(--footer-text);
+	}
+
 
 	/* focus-within */
 		#masthead .menu-item-has-children:focus-within>.sub-menu,


### PR DESCRIPTION
## Summary
- scope submenu arrow colors to masthead
- add footer-specific arrow colors

## Testing
- `phpcs --standard=WordPress style.css style-rtl.css assets/css/main.css`


------
https://chatgpt.com/codex/tasks/task_e_68c3de329fb88330bd11bdebc94f3c4b