### PR TITLE
Style comment form submission button and fields

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -244,11 +244,38 @@ blockquote {
 # 8.0 - BLOG
 --------------------------------------------------------------*/
 .comment-form-comment {
-	display: grid;
+		display: grid;
+}
+
+.comment-form input,
+.comment-form textarea {
+		width: 100%;
+		padding: 10px;
+		color: var(--form-text);
+		background-color: var(--form-bg);
+		border: 1px solid var(--form-border);
+}
+
+.comment-form label {
+		display: block;
+		margin-bottom: 10px;
+		color: var(--form-text);
+}
+
+.form-submit .btn {
+		background-color: var(--btn-bg);
+		color: var(--btn-text);
+		border: 1px solid var(--btn-border);
+}
+
+.form-submit .btn:hover {
+		background-color: var(--btn-bg-hover);
+		color: var(--btn-text-hover);
+		border: 1px solid var(--btn-border-hover);
 }
 
 .blog-col {
-	position: relative;
+		position: relative;
 }
 
 .blog-col figure {

--- a/comments.php
+++ b/comments.php
@@ -27,36 +27,36 @@ if ( post_password_required() ) {
 	if ( have_comments() ) :
 		?>
 		<h2 class="comments-title">
-			<?php
-			$smile_v6_comment_count = get_comments_number();
-			if ( '1' === $smile_v6_comment_count ) {
-				printf(
-					// translators: %1$s: post title.
-					esc_html__( 'One thought on &ldquo;%1$s&rdquo;', 'smile-web' ),
-					'<span>' . wp_kses_post( get_the_title() ) . '</span>'
-				);
-			} else {
-				printf(
-					// translators: 1: number of comments, 2: post title.
-					esc_html( _nx( '%1$s thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', $smile_v6_comment_count, 'comments title', 'smile-web' ) ),
-					esc_html( number_format_i18n( $smile_v6_comment_count ) ),
-					'<span>' . wp_kses_post( get_the_title() ) . '</span>'
-				);
-			}
-			?>
+		<?php
+		$smile_v6_comment_count = get_comments_number();
+		if ( '1' === $smile_v6_comment_count ) {
+			printf(
+			// translators: %1$s: post title.
+				esc_html__( 'One thought on &ldquo;%1$s&rdquo;', 'smile-web' ),
+				'<span>' . wp_kses_post( get_the_title() ) . '</span>'
+			);
+		} else {
+			printf(
+			// translators: 1: number of comments, 2: post title.
+				esc_html( _nx( '%1$s thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', $smile_v6_comment_count, 'comments title', 'smile-web' ) ),
+				esc_html( number_format_i18n( $smile_v6_comment_count ) ),
+				'<span>' . wp_kses_post( get_the_title() ) . '</span>'
+			);
+		}
+		?>
 		</h2><!-- .comments-title -->
 
 		<?php the_comments_navigation(); ?>
 
 		<ol class="comment-list">
-			<?php
-			wp_list_comments(
-				array(
-					'style'      => 'ol',
-					'short_ping' => true,
-				)
-			);
-			?>
+		<?php
+		wp_list_comments(
+			array(
+				'style'      => 'ol',
+				'short_ping' => true,
+			)
+		);
+		?>
 		</ol><!-- .comment-list -->
 
 		<?php
@@ -71,7 +71,13 @@ if ( post_password_required() ) {
 
 	endif; // Check for have_comments().
 
-	comment_form();
+	comment_form(
+		array(
+			'class_submit'  => 'btn',
+			'submit_button' => '<button name="%1$s" type="submit" id="%2$s" class="%3$s">%4$s</button>',
+			'submit_field'  => '<p class="form-submit btn-wrapper">%1$s %2$s</p>',
+		)
+	);
 	?>
 
 </div><!-- #comments -->

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1540,13 +1540,40 @@ textarea:focus {
 }
 
 .valid-feedback {
-	color: var(--form-success);
+		color: var(--form-success);
+}
+
+.comment-form input,
+.comment-form textarea {
+		width: 100%;
+		padding: 10px;
+		color: var(--form-text);
+		background-color: var(--form-bg);
+		border: 1px solid var(--form-border);
+}
+
+.comment-form label {
+		display: block;
+		margin-bottom: 10px;
+		color: var(--form-text);
+}
+
+.form-submit .btn {
+		background-color: var(--btn-bg);
+		color: var(--btn-text);
+		border: 1px solid var(--btn-border);
+}
+
+.form-submit .btn:hover {
+		background-color: var(--btn-bg-hover);
+		color: var(--btn-text-hover);
+		border: 1px solid var(--btn-border-hover);
 }
 
 #details {
-	background-color: var(--accent-secondary-dark);
-	text-align: center;
-	line-height: 1.2;
+		background-color: var(--accent-secondary-dark);
+		text-align: center;
+		line-height: 1.2;
 }
 
 #details span {

--- a/style.css
+++ b/style.css
@@ -1539,13 +1539,40 @@ textarea:focus {
 }
 
 .valid-feedback {
-	color: var(--form-success);
+		color: var(--form-success);
+}
+
+.comment-form input,
+.comment-form textarea {
+		width: 100%;
+		padding: 10px;
+		color: var(--form-text);
+		background-color: var(--form-bg);
+		border: 1px solid var(--form-border);
+}
+
+.comment-form label {
+		display: block;
+		margin-bottom: 10px;
+		color: var(--form-text);
+}
+
+.form-submit .btn {
+		background-color: var(--btn-bg);
+		color: var(--btn-text);
+		border: 1px solid var(--btn-border);
+}
+
+.form-submit .btn:hover {
+		background-color: var(--btn-bg-hover);
+		color: var(--btn-text-hover);
+		border: 1px solid var(--btn-border-hover);
 }
 
 #details {
-	background-color: var(--accent-secondary-dark);
-	text-align: center;
-	line-height: 1.2;
+		background-color: var(--accent-secondary-dark);
+		text-align: center;
+		line-height: 1.2;
 }
 
 #details span {


### PR DESCRIPTION
## Summary
- Customize `comment_form()` to output a `<button class="btn">` and add a `btn-wrapper` container class
- Style comment form inputs, labels, and submit button and propagate styles to RTL and compiled CSS

## Testing
- `/root/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs --standard=WordPress comments.php style.css assets/css/main.css`


------
https://chatgpt.com/codex/tasks/task_e_68c8114d5550833082b3272cd8ea8e48