### PR TITLE
Add fluid typography support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -83,3 +83,10 @@ if ( defined( 'JETPACK__VERSION' ) ) {
  * agregando atributos como target="_blank" y rel="noopener noreferrer".
  */
 require get_template_directory() . '/inc/class-social-walker.php';
+
+add_action(
+        'after_setup_theme',
+        function () {
+                add_theme_support( 'appearance-tools' );
+        }
+);

--- a/readme.txt
+++ b/readme.txt
@@ -58,6 +58,10 @@ Full Font Awesome Free license: https://fontawesome.com/license/free.
 
 Color selections should provide at least a 4.5:1 contrast ratio between text and background to meet WCAG 2.1 AA requirements.
 
+== Style Guidelines ==
+
+Para los textos de gran tamaño en el editor de bloques, utiliza los tamaños preestablecidos (como `xxl`) en lugar de introducir un valor personalizado para aprovechar la tipografía fluida del tema.
+
 == Credits ==
 
 * Based on Underscores https://underscores.me/, (C) 2012-2020 Automattic, Inc., [GPLv2 or later](https://www.gnu.org/licenses/gpl-2.0.html)

--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "settings": {
+    "typography": {
+      "fluid": true,
+      "fontSizes": [
+        {
+          "slug": "xxl",
+          "size": "160px",
+          "fluid": {
+            "min": "72px",
+            "max": "160px"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add theme.json configuration to enable fluid typography with an xxl preset
- register appearance tools support so WordPress exposes fluid typography controls
- document the recommendation to use preset sizes for large text in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c82ee917b8833088323f90ee681beb