### PR TITLE
Adjust comment layout styles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -295,12 +295,23 @@ ol.comment-list,
 }
 
 .comment-body {
+               display: block;
+}
+
+.comment-author.vcard {
                display: flex;
+               align-items: center;
                gap: 1rem;
 }
 
 .comment-body .avatar {
-               margin-right: 1rem;
+               flex-shrink: 0;
+               margin: 0;
+}
+
+.comment-meta,
+.comment-metadata {
+               margin-bottom: 0.75rem;
 }
 
 .comment-form {
@@ -321,10 +332,6 @@ ol.comment-list,
 }
 
 @media (max-width: 600px) {
-               .comment-body {
-                               flex-direction: column;
-               }
-
                .children {
                                margin-left: 20px;
                }
@@ -332,8 +339,6 @@ ol.comment-list,
                .comment-body .avatar {
                                width: 50px;
                                height: 50px;
-                               margin-right: 0;
-                               margin-bottom: 0.5rem;
                }
 
                .comment-form {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1463,12 +1463,23 @@ ol.comment-list,
 }
 
 .comment-body {
+        display: block;
+}
+
+.comment-author.vcard {
         display: flex;
+        align-items: center;
         gap: 1rem;
 }
 
 .comment-body .avatar {
-        margin-left: 1rem;
+        flex-shrink: 0;
+        margin: 0;
+}
+
+.comment-meta,
+.comment-metadata {
+        margin-bottom: 0.75rem;
 }
 
 .comment-form {
@@ -1489,10 +1500,6 @@ ol.comment-list,
 }
 
 @media (max-width: 600px) {
-        .comment-body {
-                flex-direction: column;
-        }
-
         .children {
                 margin-right: 20px;
         }
@@ -1500,8 +1507,6 @@ ol.comment-list,
         .comment-body .avatar {
                 width: 50px;
                 height: 50px;
-                margin-left: 0;
-                margin-bottom: 0.5rem;
         }
 
         .comment-form {

--- a/style.css
+++ b/style.css
@@ -1462,12 +1462,23 @@ ol.comment-list,
 }
 
 .comment-body {
+        display: block;
+}
+
+.comment-author.vcard {
         display: flex;
+        align-items: center;
         gap: 1rem;
 }
 
 .comment-body .avatar {
-        margin-right: 1rem;
+        flex-shrink: 0;
+        margin: 0;
+}
+
+.comment-meta,
+.comment-metadata {
+        margin-bottom: 0.75rem;
 }
 
 .comment-form {
@@ -1488,10 +1499,6 @@ ol.comment-list,
 }
 
 @media (max-width: 600px) {
-        .comment-body {
-                flex-direction: column;
-        }
-
         .children {
                 margin-left: 20px;
         }
@@ -1499,8 +1506,6 @@ ol.comment-list,
         .comment-body .avatar {
                 width: 50px;
                 height: 50px;
-                margin-right: 0;
-                margin-bottom: 0.5rem;
         }
 
         .comment-form {


### PR DESCRIPTION
## Summary
- switch the comment body container back to block layout to avoid flex-based issues
- align the author avatar and name with flex styling and add spacing below the comment metadata
- mirror the same styling changes in the RTL and compiled CSS bundles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9386b97748330a5057022b8f747ee