### PR TITLE
Adjust comment meta layout and actions

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -37,6 +37,22 @@ if ( ! class_exists( 'Smile_Web_Walker_Comment' ) ) {
                         <<?php echo $tag; ?> id="comment-<?php comment_ID(); ?>" <?php comment_class( $this->has_children ? 'parent' : '', $comment ); ?>>
                                 <article id="div-comment-<?php comment_ID(); ?>" class="comment-body">
                                         <footer class="comment-meta">
+                                                <div class="comment-metadata">
+                                                        <?php
+                                                        printf(
+                                                                '<a href="%s"><time datetime="%s">%s</time></a>',
+                                                                esc_url( get_comment_link( $comment, $args ) ),
+                                                                get_comment_time( 'c' ),
+                                                                sprintf(
+                                                                        /* translators: 1: Comment date, 2: Comment time. */
+                                                                        __( '%1$s at %2$s' ),
+                                                                        get_comment_date( '', $comment ),
+                                                                        get_comment_time()
+                                                                )
+                                                        );
+                                                        ?>
+                                                </div><!-- .comment-metadata -->
+
                                                 <div class="comment-author vcard">
                                                         <?php
                                                         if ( 0 !== $args['avatar_size'] ) {
@@ -58,60 +74,6 @@ if ( ! class_exists( 'Smile_Web_Walker_Comment' ) ) {
                                                         ?>
                                                 </div><!-- .comment-author -->
 
-                                                <div class="comment-metadata">
-                                                        <?php
-                                                        printf(
-                                                                '<a href="%s"><time datetime="%s">%s</time></a>',
-                                                                esc_url( get_comment_link( $comment, $args ) ),
-                                                                get_comment_time( 'c' ),
-                                                                sprintf(
-                                                                        /* translators: 1: Comment date, 2: Comment time. */
-                                                                        __( '%1$s at %2$s' ),
-                                                                        get_comment_date( '', $comment ),
-                                                                        get_comment_time()
-                                                                )
-                                                        );
-                                                        ?>
-                                                </div><!-- .comment-metadata -->
-
-                                                <?php
-                                                $comment_reply_link = '';
-                                                if ( '1' == $comment->comment_approved || $show_pending_links ) {
-                                                        $comment_reply_link = comment_reply_link(
-                                                                array_merge(
-                                                                        $args,
-                                                                        array(
-                                                                                'add_below' => 'div-comment',
-                                                                                'depth'     => $depth,
-                                                                                'max_depth' => $args['max_depth'],
-                                                                                'before'    => '',
-                                                                                'after'     => '',
-                                                                                'echo'      => false,
-                                                                        )
-                                                                )
-                                                        );
-                                                }
-
-                                                $edit_comment_link = '';
-                                                $edit_comment_url  = get_edit_comment_link( $comment );
-                                                if ( $edit_comment_url ) {
-                                                        $edit_comment_link = sprintf(
-                                                                '<span class="edit-link"><a class="comment-edit-link" href="%1$s">%2$s</a></span>',
-                                                                esc_url( $edit_comment_url ),
-                                                                esc_html__( 'Edit', 'smile-web' )
-                                                        );
-                                                }
-
-                                                if ( $edit_comment_link || $comment_reply_link ) :
-                                                ?>
-                                                <div class="comment-actions">
-                                                        <?php echo $edit_comment_link; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                                                        <?php echo $comment_reply_link; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                                                </div><!-- .comment-actions -->
-                                                <?php
-                                                endif;
-                                                ?>
-
                                                 <?php if ( '0' == $comment->comment_approved ) : ?>
                                                 <em class="comment-awaiting-moderation"><?php echo $moderation_note; ?></em>
                                                 <?php endif; ?>
@@ -120,6 +82,32 @@ if ( ! class_exists( 'Smile_Web_Walker_Comment' ) ) {
                                         <div class="comment-content">
                                                 <?php comment_text(); ?>
                                         </div><!-- .comment-content -->
+
+                                        <?php
+                                        $edit_comment_url = get_edit_comment_link( $comment );
+                                        $can_display_reply = ( '1' == $comment->comment_approved || $show_pending_links );
+
+                                        if ( $edit_comment_url || $can_display_reply ) :
+                                        ?>
+                                        <div class="comment-actions">
+                                                <?php edit_comment_link( __( 'Edit', 'smile-web' ) ); ?>
+                                                <?php
+                                                if ( $can_display_reply ) {
+                                                        comment_reply_link(
+                                                                array_merge(
+                                                                        $args,
+                                                                        array(
+                                                                                'reply_text' => __( 'Responder', 'smile-web' ),
+                                                                                'add_below'  => 'div-comment',
+                                                                                'depth'      => $depth,
+                                                                                'max_depth'  => $args['max_depth'],
+                                                                        )
+                                                                )
+                                                        );
+                                                }
+                                                ?>
+                                        </div><!-- .comment-actions -->
+                                        <?php endif; ?>
                                 </article><!-- .comment-body -->
                         <?php
                 }


### PR DESCRIPTION
## Summary
- reorder comment metadata to appear before the author block inside each comment
- move edit and reply actions below the comment text while honoring moderation status

## Testing
- php -l comments.php

------
https://chatgpt.com/codex/tasks/task_e_68c94ca6fe588330bed2ebb1d29018cc