### PR TITLE
Move appearance tools support to theme setup

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -83,10 +83,3 @@ if ( defined( 'JETPACK__VERSION' ) ) {
  * agregando atributos como target="_blank" y rel="noopener noreferrer".
  */
 require get_template_directory() . '/inc/class-social-walker.php';
-
-add_action(
-        'after_setup_theme',
-        function () {
-                add_theme_support( 'appearance-tools' );
-        }
-);

--- a/inc/theme-setup.php
+++ b/inc/theme-setup.php
@@ -24,6 +24,7 @@ function smile_v6_setup() {
 	add_theme_support( 'automatic-feed-links' );
 	add_theme_support( 'title-tag' );
 	add_theme_support( 'post-thumbnails' );
+	add_theme_support( 'appearance-tools' );
 
 	// Register nav menus.
 	register_nav_menus(


### PR DESCRIPTION
## Summary
- remove the dedicated after_setup_theme hook from functions.php so the file only loads dependencies
- register appearance tools support inside smile_v6_setup alongside the other theme supports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c970ee752c83308192a4f19c43f621