### PR TITLE
Add editor styles support and share dynamic CSS

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -6,9 +6,11 @@
  */
 
 /**
- * Outputs inline dynamic CSS based on customizer settings.
+ * Generates the dynamic CSS variables based on Customizer settings.
+ *
+ * @return string
  */
-function smile_web_add_dynamic_styles() {
+function smile_web_get_dynamic_root_styles() {
 		$link_default                          = sanitize_hex_color( get_theme_mod( 'link_default', '#0F7B5C' ) );
 		$link_hover                            = sanitize_hex_color( get_theme_mod( 'link_hover', '#1E3A5F' ) );
 		$link_active                           = sanitize_hex_color( get_theme_mod( 'link_active', '#0F7B5C' ) );
@@ -183,8 +185,20 @@ function smile_web_add_dynamic_styles() {
                 }
         ';
 
-	// Se agrega el CSS en línea al handle 'smile-web-main'.
-	wp_add_inline_style( 'smile-web-main', $dynamic_css );
+        return apply_filters( 'smile_web_dynamic_root_styles', $dynamic_css );
+}
+
+/**
+ * Outputs inline dynamic CSS based on customizer settings.
+ */
+function smile_web_add_dynamic_styles() {
+        $dynamic_css = smile_web_get_dynamic_root_styles();
+
+        if ( empty( $dynamic_css ) ) {
+                return;
+        }
+
+        wp_add_inline_style( 'smile-web-main', $dynamic_css );
 }
 add_action( 'wp_enqueue_scripts', 'smile_web_add_dynamic_styles' );
 

--- a/inc/enqueues.php
+++ b/inc/enqueues.php
@@ -10,6 +10,24 @@
  */
 
 /**
+ * Returns the shared font-family CSS variables used across the theme.
+ *
+ * @return string
+ */
+function smile_v6_get_root_font_variables_css() {
+        $css = <<<CSS
+:root {
+    --font-family: "Roboto Regular", sans-serif;
+    --font-family-bold: "Roboto Bold", sans-serif;
+    --font-family-black: "Roboto Black", sans-serif;
+}
+
+CSS;
+
+        return $css;
+}
+
+/**
  * Enqueues front-end styles and scripts.
  *
  * Encola el stylesheet principal, un stylesheet adicional, y los scripts necesarios.
@@ -19,55 +37,51 @@
  */
 function smile_v6_enqueue_scripts() {
 
-	// Encolar el stylesheet principal.
-	wp_enqueue_style(
-		'smile-web-style',
-		get_stylesheet_uri(),
-		array(),
-		defined( '_S_VERSION' ) ? _S_VERSION : '1.0.0'
-	);
+        // Encolar el stylesheet principal.
+        wp_enqueue_style(
+                'smile-web-style',
+                get_stylesheet_uri(),
+                array(),
+                defined( '_S_VERSION' ) ? _S_VERSION : '1.0.0'
+        );
 
-	// Encolar un stylesheet adicional para estilos personalizados.
-	wp_enqueue_style(
-		'smile-web-main',
-		get_template_directory_uri() . '/assets/css/main.css',
-		array(),
-		defined( '_S_VERSION' ) ? _S_VERSION : '1.0.0'
-	);
+        // Encolar un stylesheet adicional para estilos personalizados.
+        wp_enqueue_style(
+                'smile-web-main',
+                get_template_directory_uri() . '/assets/css/main.css',
+                array(),
+                defined( '_S_VERSION' ) ? _S_VERSION : '1.0.0'
+        );
 
-	// Agregar soporte RTL si es necesario.
-	wp_style_add_data( 'smile-web-style', 'rtl', 'replace' );
+        // Agregar soporte RTL si es necesario.
+        wp_style_add_data( 'smile-web-style', 'rtl', 'replace' );
 
-	// Encolar script de navegación (vanilla JS).
-	wp_enqueue_script(
-		'smile-web-navigation',
-		get_template_directory_uri() . '/assets/js/navigation.js',
-		array(),
-		defined( '_S_VERSION' ) ? _S_VERSION : '1.0.0',
-		true
-	);
+        // Encolar script de navegación (vanilla JS).
+        wp_enqueue_script(
+                'smile-web-navigation',
+                get_template_directory_uri() . '/assets/js/navigation.js',
+                array(),
+                defined( '_S_VERSION' ) ? _S_VERSION : '1.0.0',
+                true
+        );
 
-	// Encolar el script principal (vanilla JS).
-	wp_enqueue_script(
-		'smile-web-main-js',
-		get_template_directory_uri() . '/assets/js/main.js',
-		array(),
-		defined( '_S_VERSION' ) ? _S_VERSION : '1.0.0',
-		true
-	);
+        // Encolar el script principal (vanilla JS).
+        wp_enqueue_script(
+                'smile-web-main-js',
+                get_template_directory_uri() . '/assets/js/main.js',
+                array(),
+                defined( '_S_VERSION' ) ? _S_VERSION : '1.0.0',
+                true
+        );
 
-	/**
-	 * Generación de estilos dinámicos en línea.
-	 *
-	 * Los estilos que antes se definían en $style_home en el header ahora se generan
-	 * aquí y se añaden al stylesheet principal utilizando wp_add_inline_style().
-	 */
-	$dynamic_css = '
-:root {
-    --font-family: "Roboto Regular", sans-serif;
-    --font-family-bold: "Roboto Bold", sans-serif;
-    --font-family-black: "Roboto Black", sans-serif;
-}
+        /**
+         * Generación de estilos dinámicos en línea.
+         *
+         * Los estilos que antes se definían en $style_home en el header ahora se generan
+         * aquí y se añaden al stylesheet principal utilizando wp_add_inline_style().
+         */
+        $dynamic_css  = smile_v6_get_root_font_variables_css();
+        $dynamic_css .= <<<CSS
 #topBar .container {
     display: flex;
     flex-wrap: wrap;
@@ -145,21 +159,23 @@ function smile_v6_enqueue_scripts() {
 #intro-carousel {
     display: none;
 }
-	';
 
-	// Si no existe logo personalizado, agregar estilos para el título.
-	if ( ! has_custom_logo() ) {
-		$dynamic_css .= '
+CSS;
+
+        // Si no existe logo personalizado, agregar estilos para el título.
+        if ( ! has_custom_logo() ) {
+                $dynamic_css .= <<<CSS
 #logo h3 a {
     text-decoration: none;
     font-size: 30px;
 }
-		';
-	}
 
-	// Estilos según el tipo de página.
-	if ( is_front_page() ) {
-		$dynamic_css .= '
+CSS;
+        }
+
+        // Estilos según el tipo de página.
+        if ( is_front_page() ) {
+                $dynamic_css .= <<<CSS
 #intro {
     background-color: var(--accent-secondary-dark);
     color: var(--single-intro-heading);
@@ -242,17 +258,18 @@ function smile_v6_enqueue_scripts() {
         justify-content: space-between;
     }
 }
-		';
-	} elseif ( is_page() ) {
-				$dynamic_css .= '
+
+CSS;
+        } elseif ( is_page() ) {
+                $dynamic_css .= <<<CSS
 #intro {
-        background-color: var(--page-intro-bg);
+    background-color: var(--page-intro-bg);
     color: var(--single-intro-heading);
     position: relative;
     z-index: 0;
     min-height: 300px;
 }
-    #intro h1 {
+#intro h1 {
     color: var(--page-intro-heading);
     width: 100%;
 }
@@ -315,16 +332,17 @@ function smile_v6_enqueue_scripts() {
         justify-content: space-between;
     }
 }
-		';
-	} else {
-				$dynamic_css .= '
+
+CSS;
+        } else {
+                $dynamic_css .= <<<CSS
 #intro {
     background-color: var(--single-intro-bg);
     color: var(--single-intro-heading);
     position: relative;
     z-index: 0;
 }
-    #intro h1 {
+#intro h1 {
     color: var(--single-intro-heading);
     width: 100%;
 }
@@ -357,11 +375,12 @@ function smile_v6_enqueue_scripts() {
     padding: 0;
     margin: 0;
 }
-		';
-	}
 
-	// Agregar el CSS en línea al stylesheet principal.
-	wp_add_inline_style( 'smile-web-style', $dynamic_css );
+CSS;
+        }
+
+        // Agregar el CSS en línea al stylesheet principal.
+        wp_add_inline_style( 'smile-web-style', $dynamic_css );
 
 	// Encolar el script de comentarios para respuestas en hilos si es necesario.
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
@@ -369,6 +388,26 @@ function smile_v6_enqueue_scripts() {
 	}
 }
 add_action( 'wp_enqueue_scripts', 'smile_v6_enqueue_scripts' );
+
+/**
+ * Enqueues shared styles for the block editor so it mirrors the front-end.
+ */
+function smile_v6_enqueue_block_editor_styles() {
+        $static_css = smile_v6_get_root_font_variables_css();
+
+        if ( ! empty( $static_css ) ) {
+                wp_add_inline_style( 'wp-block-library', $static_css );
+        }
+
+        if ( function_exists( 'smile_web_get_dynamic_root_styles' ) ) {
+                $dynamic_css = smile_web_get_dynamic_root_styles();
+
+                if ( ! empty( $dynamic_css ) ) {
+                        wp_add_inline_style( 'wp-block-library', $dynamic_css );
+                }
+        }
+}
+add_action( 'enqueue_block_editor_assets', 'smile_v6_enqueue_block_editor_styles' );
 
 /**
  * Enqueues footer scripts.

--- a/inc/theme-setup.php
+++ b/inc/theme-setup.php
@@ -23,8 +23,10 @@ function smile_v6_setup() {
 
 	add_theme_support( 'automatic-feed-links' );
 	add_theme_support( 'title-tag' );
-	add_theme_support( 'post-thumbnails' );
-	add_theme_support( 'appearance-tools' );
+        add_theme_support( 'post-thumbnails' );
+        add_theme_support( 'appearance-tools' );
+        add_theme_support( 'editor-styles' );
+        add_editor_style( 'assets/css/editor-style.css' );
 
 	// Register nav menus.
 	register_nav_menus(


### PR DESCRIPTION
## Summary
- enable editor stylesheet support during theme setup so Gutenberg loads the theme styles
- refactor the frontend dynamic CSS generator to share the :root font variables
- expose the Customizer-generated CSS variables via a reusable helper and load them inside the block editor

## Testing
- php -l inc/theme-setup.php
- php -l inc/enqueues.php
- php -l inc/customizer-dynamic-styles.php

------
https://chatgpt.com/codex/tasks/task_e_68be9feb94a88330b9bc2b4c3d4f80e5