### PR TITLE
Restore classic editor appearance while keeping theme.json

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -6,195 +6,242 @@
  */
 
 /**
- * Outputs inline dynamic CSS based on customizer settings.
+ * Builds the dynamic CSS variables shared between the front-end and the editor.
+ *
+ * @return string CSS string containing the :root variables.
+ */
+function smile_web_get_dynamic_css_variables() {
+        $link_default             = sanitize_hex_color( get_theme_mod( 'link_default', '#0F7B5C' ) );
+        $link_hover               = sanitize_hex_color( get_theme_mod( 'link_hover', '#1E3A5F' ) );
+        $link_active              = sanitize_hex_color( get_theme_mod( 'link_active', '#0F7B5C' ) );
+        $link_visited             = sanitize_hex_color( get_theme_mod( 'link_visited', '#2E5984' ) );
+        $comment_color            = sanitize_hex_color( get_theme_mod( 'comment_color', '#0F7B5C' ) );
+        $card_text_color          = sanitize_hex_color( get_theme_mod( 'card_text_color', '#1A202C' ) );
+        $color_warning            = sanitize_hex_color( get_theme_mod( 'color_warning', '#E67E22' ) );
+        $cta_bg                   = sanitize_hex_color( get_theme_mod( 'cta_bg', '#E67E22' ) );
+        $breadcrumb_separator     = sanitize_text_field( get_theme_mod( 'breadcrumb_separator', '/' ) );
+        $text_base                = sanitize_hex_color( get_theme_mod( 'text_base', '#1A202C' ) );
+        $text_muted               = sanitize_hex_color( get_theme_mod( 'text_muted', '#64748B' ) );
+        $text_heading             = sanitize_hex_color( get_theme_mod( 'text_heading', '#1E3A5F' ) );
+        $text_subheading          = sanitize_hex_color( get_theme_mod( 'text_subheading', '#2E5984' ) );
+        $text_emphasis            = sanitize_hex_color( get_theme_mod( 'text_emphasis', '#0F7B5C' ) );
+        $text_quote               = sanitize_hex_color( get_theme_mod( 'text_quote', '#2E5984' ) );
+        $text_list                = sanitize_hex_color( get_theme_mod( 'text_list', '#1A202C' ) );
+        $accent_primary_light     = sanitize_hex_color( get_theme_mod( 'accent-primary-light', '#E8F2FF' ) );
+        $accent_primary           = sanitize_hex_color( get_theme_mod( 'accent-primary', '#E8F2FF' ) );
+        $accent_secondary         = sanitize_hex_color( get_theme_mod( 'accent-secondary', '#2E5984' ) );
+        $accent_secondary_dark    = sanitize_hex_color( get_theme_mod( 'accent-secondary-dark', '#0B1426' ) );
+        $front_intro_overlay_hex  = sanitize_hex_color( get_theme_mod( 'front_intro_overlay', '#0B1426' ) );
+        $front_intro_overlay_hex  = $front_intro_overlay_hex ? $front_intro_overlay_hex : '#0B1426';
+        $front_intro_overlay_alpha = floatval( get_theme_mod( 'front_intro_overlay_alpha', 0.8 ) );
+        $front_intro_overlay_alpha = min( 1, max( 0, $front_intro_overlay_alpha ) );
+        list( $fio_r, $fio_g, $fio_b ) = sscanf( $front_intro_overlay_hex, '#%02x%02x%02x' );
+        $front_intro_overlay = sprintf( 'rgba(%d,%d,%d,%s)', $fio_r, $fio_g, $fio_b, $front_intro_overlay_alpha );
+        $front_intro_heading  = sanitize_hex_color( get_theme_mod( 'front_intro_heading', '#E8F2FF' ) );
+        $front_intro_text     = sanitize_hex_color( get_theme_mod( 'front_intro_text', '#FFFFFF' ) );
+        $page_intro_bg_hex    = sanitize_hex_color( get_theme_mod( 'page_intro_bg', '#0B1426' ) );
+        $page_intro_bg_hex    = $page_intro_bg_hex ? $page_intro_bg_hex : '#0B1426';
+        $page_intro_bg_alpha  = floatval( get_theme_mod( 'page_intro_bg_alpha', 1 ) );
+        $page_intro_bg_alpha  = min( 1, max( 0, $page_intro_bg_alpha ) );
+        list( $pib_r, $pib_g, $pib_b ) = sscanf( $page_intro_bg_hex, '#%02x%02x%02x' );
+        $page_intro_bg       = sprintf( 'rgba(%d,%d,%d,%s)', $pib_r, $pib_g, $pib_b, $page_intro_bg_alpha );
+        $page_intro_heading  = sanitize_hex_color( get_theme_mod( 'page_intro_heading', '#E8F2FF' ) );
+        $single_intro_bg_hex = sanitize_hex_color( get_theme_mod( 'single_intro_bg', '#0B1426' ) );
+        $single_intro_bg_hex = $single_intro_bg_hex ? $single_intro_bg_hex : '#0B1426';
+        $single_intro_bg_alpha = floatval( get_theme_mod( 'single_intro_bg_alpha', 1 ) );
+        $single_intro_bg_alpha = min( 1, max( 0, $single_intro_bg_alpha ) );
+        list( $sib_r, $sib_g, $sib_b ) = sscanf( $single_intro_bg_hex, '#%02x%02x%02x' );
+        $single_intro_bg      = sprintf( 'rgba(%d,%d,%d,%s)', $sib_r, $sib_g, $sib_b, $single_intro_bg_alpha );
+        $single_intro_heading = sanitize_hex_color( get_theme_mod( 'single_intro_heading', '#E8F2FF' ) );
+        $bg_primary           = sanitize_hex_color( get_theme_mod( 'bg_primary', '#F7FAFC' ) );
+        $bg_secondary         = sanitize_hex_color( get_theme_mod( 'bg_secondary', '#E8F2FF' ) );
+        $breadcrumb_bg        = sanitize_hex_color( get_theme_mod( 'breadcrumb_bg_color', '#F7FAFC' ) );
+        $button_text          = sanitize_hex_color( get_theme_mod( 'button_text', '#FFFFFF' ) );
+        $button_text_hover    = sanitize_hex_color( get_theme_mod( 'button_text_hover', '#0F7B5C' ) );
+        $button_bg            = sanitize_hex_color( get_theme_mod( 'button_bg', '#0F7B5C' ) );
+        $button_bg_hover      = sanitize_hex_color( get_theme_mod( 'button_bg_hover', '#FFFFFF' ) );
+        $button_border        = sanitize_hex_color( get_theme_mod( 'button_border', '#0F7B5C' ) );
+        $button_border_hover  = sanitize_hex_color( get_theme_mod( 'button_border_hover', '#0F7B5C' ) );
+        $form_text            = sanitize_hex_color( get_theme_mod( 'form_text', '#1A202C' ) );
+        $form_placeholder     = sanitize_hex_color( get_theme_mod( 'form_placeholder', '#64748B' ) );
+        $form_border          = sanitize_hex_color( get_theme_mod( 'form_border', '#E2E8F0' ) );
+        $form_border_focus    = sanitize_hex_color( get_theme_mod( 'form_border_focus', '#0F7B5C' ) );
+        $form_bg              = sanitize_hex_color( get_theme_mod( 'form_bg', '#FFFFFF' ) );
+        $form_error           = sanitize_hex_color( get_theme_mod( 'form_error', '#E53E3E' ) );
+        $form_success         = sanitize_hex_color( get_theme_mod( 'form_success', '#0F7B5C' ) );
+        $alert_success        = sanitize_hex_color( get_theme_mod( 'alert_success', '#0F7B5C' ) );
+        $alert_error          = sanitize_hex_color( get_theme_mod( 'alert_error', '#E53E3E' ) );
+        $alert_warning        = sanitize_hex_color( get_theme_mod( 'alert_warning', '#E67E22' ) );
+        $alert_info           = sanitize_hex_color( get_theme_mod( 'alert_info', '#1E3A5F' ) );
+        $topbar_bg            = sanitize_hex_color( get_theme_mod( 'topbar_bg', '#F7FAFC' ) );
+        $topbar_text          = sanitize_hex_color( get_theme_mod( 'topbar_text', '#1A202C' ) );
+        $topbar_link          = sanitize_hex_color( get_theme_mod( 'topbar_link', '#0F7B5C' ) );
+        $topbar_link_hover    = sanitize_hex_color( get_theme_mod( 'topbar_link_hover', '#1E3A5F' ) );
+        $topbar_social_icon   = sanitize_hex_color( get_theme_mod( 'topbar_social_icon', '#0B1426' ) );
+        $masthead_bg          = sanitize_hex_color( get_theme_mod( 'masthead_bg', '#0B1426' ) );
+        $masthead_submenu_bg  = sanitize_hex_color( get_theme_mod( 'masthead_submenu_bg', '#0B1426' ) );
+        $masthead_submenu_text = sanitize_hex_color( get_theme_mod( 'masthead_submenu_text', '#E8F2FF' ) );
+        $masthead_text        = sanitize_hex_color( get_theme_mod( 'masthead_text', '#E8F2FF' ) );
+        $masthead_link        = sanitize_hex_color( get_theme_mod( 'masthead_link', '#E8F2FF' ) );
+        $masthead_link_hover  = sanitize_hex_color( get_theme_mod( 'masthead_link_hover', '#1E3A5F' ) );
+        $masthead_scrolled_bg = sanitize_hex_color( get_theme_mod( 'masthead_scrolled_bg', '#E8F2FF' ) );
+        $footer_bg            = sanitize_hex_color( get_theme_mod( 'footer_bg', '#1E3A5F' ) );
+        $footer_text          = sanitize_hex_color( get_theme_mod( 'footer_text', '#FFFFFF' ) );
+        $footer_link          = sanitize_hex_color( get_theme_mod( 'footer_link_color', '#0F7B5C' ) );
+        $footer_link_hover    = sanitize_hex_color( get_theme_mod( 'footer_link_hover_color', '#E8F2FF' ) );
+        $footer_border        = sanitize_hex_color( get_theme_mod( 'footer_border_color', '#2E5984' ) );
+        $footer_social_bg     = sanitize_hex_color( get_theme_mod( 'footer_social_bg', '#0F7B5C' ) );
+        $footer_social_icon   = sanitize_hex_color( get_theme_mod( 'footer_social_icon', '#FFFFFF' ) );
+        $footer_social_icon_hover = sanitize_hex_color( get_theme_mod( 'footer_social_icon_hover', '#0F7B5C' ) );
+        $color_white          = sanitize_hex_color( '#FFFFFF' );
+        $border_color         = sanitize_hex_color( get_theme_mod( 'border_color', '#E2E8F0' ) );
+        $footer_top_bg        = sanitize_hex_color( get_theme_mod( 'footer_top_bg', '#1E3A5F' ) );
+        $selection_bg         = sanitize_hex_color( get_theme_mod( 'selection_bg', '#1E3A5F' ) );
+        $icon_color           = sanitize_hex_color( get_theme_mod( 'icon_color', '#0B1426' ) );
+        $toc_link             = sanitize_hex_color( get_theme_mod( 'toc_link', '#0F7B5C' ) );
+        $category_bg          = sanitize_hex_color( get_theme_mod( 'category_bg', '#0F7B5C' ) );
+        $category_bg_hover    = sanitize_hex_color( get_theme_mod( 'category_bg_hover', '#1E3A5F' ) );
+        $category_text        = sanitize_hex_color( get_theme_mod( 'category_text', '#FFFFFF' ) );
+        $category_text_hover  = sanitize_hex_color( get_theme_mod( 'category_text_hover', '#FFFFFF' ) );
+        $modal_border         = sanitize_hex_color( '#64748B' );
+
+        $variables = array(
+                '--link'                     => esc_attr( $link_default ),
+                '--link-hover'               => esc_attr( $link_hover ),
+                '--link-active'              => esc_attr( $link_active ),
+                '--link-visited'             => esc_attr( $link_visited ),
+                '--comment-color'            => esc_attr( $comment_color ),
+                '--card-text-color'          => esc_attr( $card_text_color ),
+                '--color-warning'            => esc_attr( $color_warning ),
+                '--cta-bg'                   => esc_attr( $cta_bg ),
+                '--breadcrumb-separator'     => esc_attr( $breadcrumb_separator ),
+                '--text-base'                => esc_attr( $text_base ),
+                '--text-muted'               => esc_attr( $text_muted ),
+                '--text-heading'             => esc_attr( $text_heading ),
+                '--text-subheading'          => esc_attr( $text_subheading ),
+                '--text-emphasis'            => esc_attr( $text_emphasis ),
+                '--text-quote'               => esc_attr( $text_quote ),
+                '--text-list'                => esc_attr( $text_list ),
+                '--accent-primary-light'     => esc_attr( $accent_primary_light ),
+                '--accent-primary'           => esc_attr( $accent_primary ),
+                '--accent-secondary'         => esc_attr( $accent_secondary ),
+                '--accent-secondary-dark'    => esc_attr( $accent_secondary_dark ),
+                '--color-white'              => esc_attr( $color_white ),
+                '--bg-primary'               => esc_attr( $bg_primary ),
+                '--bg-secondary'             => esc_attr( $bg_secondary ),
+                '--breadcrumb-bg'            => esc_attr( $breadcrumb_bg ),
+                '--front-intro-overlay'      => esc_attr( $front_intro_overlay ),
+                '--front-intro-heading'      => esc_attr( $front_intro_heading ),
+                '--front-intro-text'         => esc_attr( $front_intro_text ),
+                '--page-intro-bg'            => esc_attr( $page_intro_bg ),
+                '--page-intro-heading'       => esc_attr( $page_intro_heading ),
+                '--single-intro-bg'          => esc_attr( $single_intro_bg ),
+                '--single-intro-heading'     => esc_attr( $single_intro_heading ),
+                '--btn-text'                 => esc_attr( $button_text ),
+                '--btn-text-hover'           => esc_attr( $button_text_hover ),
+                '--btn-bg'                   => esc_attr( $button_bg ),
+                '--btn-bg-hover'             => esc_attr( $button_bg_hover ),
+                '--btn-border'               => esc_attr( $button_border ),
+                '--btn-border-hover'         => esc_attr( $button_border_hover ),
+                '--form-text'                => esc_attr( $form_text ),
+                '--form-placeholder'         => esc_attr( $form_placeholder ),
+                '--form-border'              => esc_attr( $form_border ),
+                '--form-border-focus'        => esc_attr( $form_border_focus ),
+                '--form-bg'                  => esc_attr( $form_bg ),
+                '--form-error'               => esc_attr( $form_error ),
+                '--form-success'             => esc_attr( $form_success ),
+                '--alert-success'            => esc_attr( $alert_success ),
+                '--alert-error'              => esc_attr( $alert_error ),
+                '--alert-warning'            => esc_attr( $alert_warning ),
+                '--alert-info'               => esc_attr( $alert_info ),
+                '--topbar-bg'                => esc_attr( $topbar_bg ),
+                '--topbar-text'              => esc_attr( $topbar_text ),
+                '--topbar-link'              => esc_attr( $topbar_link ),
+                '--topbar-link-hover'        => esc_attr( $topbar_link_hover ),
+                '--topbar-social-icon'       => esc_attr( $topbar_social_icon ),
+                '--masthead-bg'              => esc_attr( $masthead_bg ),
+                '--masthead-submenu-bg'      => esc_attr( $masthead_submenu_bg ),
+                '--masthead-submenu-text'    => esc_attr( $masthead_submenu_text ),
+                '--masthead-text'            => esc_attr( $masthead_text ),
+                '--masthead-link'            => esc_attr( $masthead_link ),
+                '--masthead-link-hover'      => esc_attr( $masthead_link_hover ),
+                '--masthead-scrolled-bg'     => esc_attr( $masthead_scrolled_bg ),
+                '--footer-bg'                => esc_attr( $footer_bg ),
+                '--footer-text'              => esc_attr( $footer_text ),
+                '--footer-link'              => esc_attr( $footer_link ),
+                '--footer-link-hover'        => esc_attr( $footer_link_hover ),
+                '--footer-border'            => esc_attr( $footer_border ),
+                '--footer-social-bg'         => esc_attr( $footer_social_bg ),
+                '--footer-social-icon'       => esc_attr( $footer_social_icon ),
+                '--footer-social-icon-hover' => esc_attr( $footer_social_icon_hover ),
+                '--border'                   => esc_attr( $border_color ),
+                '--footer-top-bg'            => esc_attr( $footer_top_bg ),
+                '--selection-bg'             => esc_attr( $selection_bg ),
+                '--icon'                     => esc_attr( $icon_color ),
+                '--category-bg'              => esc_attr( $category_bg ),
+                '--category-bg-hover'        => esc_attr( $category_bg_hover ),
+                '--category-text'            => esc_attr( $category_text ),
+                '--category-text-hover'      => esc_attr( $category_text_hover ),
+                '--toc-link'                 => esc_attr( $toc_link ),
+                '--modal-border'             => esc_attr( $modal_border ),
+        );
+
+        $lines = array( ':root {' );
+
+        foreach ( $variables as $variable => $value ) {
+                if ( '--breadcrumb-separator' === $variable && '' !== $value ) {
+                        $value = chr( 34 ) . $value . chr( 34 );
+                }
+
+                $lines[] = "\t{$variable}: {$value};";
+        }
+
+        $lines[] = '}';
+
+        return implode( "\n", $lines ) . "\n";
+}
+
+/**
+ * Outputs inline dynamic CSS based on customizer settings for the front-end.
  */
 function smile_web_add_dynamic_styles() {
-		$link_default                          = sanitize_hex_color( get_theme_mod( 'link_default', '#0F7B5C' ) );
-		$link_hover                            = sanitize_hex_color( get_theme_mod( 'link_hover', '#1E3A5F' ) );
-		$link_active                           = sanitize_hex_color( get_theme_mod( 'link_active', '#0F7B5C' ) );
-		$link_visited                          = sanitize_hex_color( get_theme_mod( 'link_visited', '#2E5984' ) );
-		$comment_color                         = sanitize_hex_color( get_theme_mod( 'comment_color', '#0F7B5C' ) );
-		$card_text_color                       = sanitize_hex_color( get_theme_mod( 'card_text_color', '#1A202C' ) );
-		$color_warning                         = sanitize_hex_color( get_theme_mod( 'color_warning', '#E67E22' ) );
-		$cta_bg                                = sanitize_hex_color( get_theme_mod( 'cta_bg', '#E67E22' ) );
-		$breadcrumb_separator                  = sanitize_text_field( get_theme_mod( 'breadcrumb_separator', '/' ) );
-		$text_base                             = sanitize_hex_color( get_theme_mod( 'text_base', '#1A202C' ) );
-		$text_muted                            = sanitize_hex_color( get_theme_mod( 'text_muted', '#64748B' ) );
-		$text_heading                          = sanitize_hex_color( get_theme_mod( 'text_heading', '#1E3A5F' ) );
-		$text_subheading                       = sanitize_hex_color( get_theme_mod( 'text_subheading', '#2E5984' ) );
-		$text_emphasis                         = sanitize_hex_color( get_theme_mod( 'text_emphasis', '#0F7B5C' ) );
-		$text_quote                            = sanitize_hex_color( get_theme_mod( 'text_quote', '#2E5984' ) );
-		$text_list                             = sanitize_hex_color( get_theme_mod( 'text_list', '#1A202C' ) );
-		$accent_primary_light                  = sanitize_hex_color( get_theme_mod( 'accent-primary-light', '#E8F2FF' ) );
-				$accent_primary                = sanitize_hex_color( get_theme_mod( 'accent-primary', '#E8F2FF' ) );
-				$accent_secondary              = sanitize_hex_color( get_theme_mod( 'accent-secondary', '#2E5984' ) );
-				$accent_secondary_dark         = sanitize_hex_color( get_theme_mod( 'accent-secondary-dark', '#0B1426' ) );
-				$front_intro_overlay_color     = sanitize_hex_color( get_theme_mod( 'front_intro_overlay', '#0B1426' ) );
-				$front_intro_overlay_alpha     = floatval( get_theme_mod( 'front_intro_overlay_alpha', 0.8 ) );
-				$front_intro_overlay_alpha     = min( 1, max( 0, $front_intro_overlay_alpha ) );
-				list( $fio_r, $fio_g, $fio_b ) = sscanf( $front_intro_overlay_color, '#%02x%02x%02x' );
-				$front_intro_overlay           = sprintf( 'rgba(%d,%d,%d,%s)', $fio_r, $fio_g, $fio_b, $front_intro_overlay_alpha );
-				$front_intro_heading           = sanitize_hex_color( get_theme_mod( 'front_intro_heading', '#E8F2FF' ) );
-				$front_intro_text              = sanitize_hex_color( get_theme_mod( 'front_intro_text', '#FFFFFF' ) );
-				$page_intro_bg_color           = sanitize_hex_color( get_theme_mod( 'page_intro_bg', '#0B1426' ) );
-				$page_intro_bg_alpha           = floatval( get_theme_mod( 'page_intro_bg_alpha', 1 ) );
-				$page_intro_bg_alpha           = min( 1, max( 0, $page_intro_bg_alpha ) );
-				list( $pib_r, $pib_g, $pib_b ) = sscanf( $page_intro_bg_color, '#%02x%02x%02x' );
-				$page_intro_bg                 = sprintf( 'rgba(%d,%d,%d,%s)', $pib_r, $pib_g, $pib_b, $page_intro_bg_alpha );
-				$page_intro_heading            = sanitize_hex_color( get_theme_mod( 'page_intro_heading', '#E8F2FF' ) );
-				$single_intro_bg_color         = sanitize_hex_color( get_theme_mod( 'single_intro_bg', '#0B1426' ) );
-				$single_intro_bg_alpha         = floatval( get_theme_mod( 'single_intro_bg_alpha', 1 ) );
-				$single_intro_bg_alpha         = min( 1, max( 0, $single_intro_bg_alpha ) );
-				list( $sib_r, $sib_g, $sib_b ) = sscanf( $single_intro_bg_color, '#%02x%02x%02x' );
-				$single_intro_bg               = sprintf( 'rgba(%d,%d,%d,%s)', $sib_r, $sib_g, $sib_b, $single_intro_bg_alpha );
-				$single_intro_heading          = sanitize_hex_color( get_theme_mod( 'single_intro_heading', '#E8F2FF' ) );
-				$bg_primary                    = sanitize_hex_color( get_theme_mod( 'bg_primary', '#F7FAFC' ) );
-				$bg_secondary                  = sanitize_hex_color( get_theme_mod( 'bg_secondary', '#E8F2FF' ) );
-				$breadcrumb_bg                 = sanitize_hex_color( get_theme_mod( 'breadcrumb_bg_color', '#F7FAFC' ) );
-				$button_text                   = sanitize_hex_color( get_theme_mod( 'button_text', '#FFFFFF' ) );
-				$button_text_hover             = sanitize_hex_color( get_theme_mod( 'button_text_hover', '#0F7B5C' ) );
-				$button_bg                     = sanitize_hex_color( get_theme_mod( 'button_bg', '#0F7B5C' ) );
-				$button_bg_hover               = sanitize_hex_color( get_theme_mod( 'button_bg_hover', '#FFFFFF' ) );
-				$button_border                 = sanitize_hex_color( get_theme_mod( 'button_border', '#0F7B5C' ) );
-				$button_border_hover           = sanitize_hex_color( get_theme_mod( 'button_border_hover', '#0F7B5C' ) );
-				$form_text                     = sanitize_hex_color( get_theme_mod( 'form_text', '#1A202C' ) );
-				$form_placeholder              = sanitize_hex_color( get_theme_mod( 'form_placeholder', '#64748B' ) );
-				$form_border                   = sanitize_hex_color( get_theme_mod( 'form_border', '#E2E8F0' ) );
-				$form_border_focus             = sanitize_hex_color( get_theme_mod( 'form_border_focus', '#0F7B5C' ) );
-				$form_bg                       = sanitize_hex_color( get_theme_mod( 'form_bg', '#FFFFFF' ) );
-				$form_error                    = sanitize_hex_color( get_theme_mod( 'form_error', '#E53E3E' ) );
-				$form_success                  = sanitize_hex_color( get_theme_mod( 'form_success', '#0F7B5C' ) );
-				$alert_success                 = sanitize_hex_color( get_theme_mod( 'alert_success', '#0F7B5C' ) );
-				$alert_error                   = sanitize_hex_color( get_theme_mod( 'alert_error', '#E53E3E' ) );
-				$alert_warning                 = sanitize_hex_color( get_theme_mod( 'alert_warning', '#E67E22' ) );
-				$alert_info                    = sanitize_hex_color( get_theme_mod( 'alert_info', '#1E3A5F' ) );
-				$topbar_bg                     = sanitize_hex_color( get_theme_mod( 'topbar_bg', '#F7FAFC' ) );
-		$topbar_text                           = sanitize_hex_color( get_theme_mod( 'topbar_text', '#1A202C' ) );
-		$topbar_link                           = sanitize_hex_color( get_theme_mod( 'topbar_link', '#0F7B5C' ) );
-		$topbar_link_hover                     = sanitize_hex_color( get_theme_mod( 'topbar_link_hover', '#1E3A5F' ) );
-		$topbar_social_icon                    = sanitize_hex_color( get_theme_mod( 'topbar_social_icon', '#0B1426' ) );
-		$masthead_bg                           = sanitize_hex_color( get_theme_mod( 'masthead_bg', '#0B1426' ) );
-		$masthead_submenu_bg                   = sanitize_hex_color( get_theme_mod( 'masthead_submenu_bg', '#0B1426' ) );
-		$masthead_submenu_text                 = sanitize_hex_color( get_theme_mod( 'masthead_submenu_text', '#E8F2FF' ) );
-		$masthead_text                         = sanitize_hex_color( get_theme_mod( 'masthead_text', '#E8F2FF' ) );
-		$masthead_link                         = sanitize_hex_color( get_theme_mod( 'masthead_link', '#E8F2FF' ) );
-		$masthead_link_hover                   = sanitize_hex_color( get_theme_mod( 'masthead_link_hover', '#1E3A5F' ) );
-		$masthead_scrolled_bg                  = sanitize_hex_color( get_theme_mod( 'masthead_scrolled_bg', '#E8F2FF' ) );
-		$footer_bg                             = sanitize_hex_color( get_theme_mod( 'footer_bg', '#1E3A5F' ) );
-		$footer_text                           = sanitize_hex_color( get_theme_mod( 'footer_text', '#FFFFFF' ) );
-		$footer_link                           = sanitize_hex_color( get_theme_mod( 'footer_link_color', '#0F7B5C' ) );
-				$footer_link_hover             = sanitize_hex_color( get_theme_mod( 'footer_link_hover_color', '#E8F2FF' ) );
-				$footer_border                 = sanitize_hex_color( get_theme_mod( 'footer_border_color', '#2E5984' ) );
-		$footer_social_bg                      = sanitize_hex_color( get_theme_mod( 'footer_social_bg', '#0F7B5C' ) );
-		$footer_social_icon                    = sanitize_hex_color( get_theme_mod( 'footer_social_icon', '#FFFFFF' ) );
-		$footer_social_icon_hover              = sanitize_hex_color( get_theme_mod( 'footer_social_icon_hover', '#0F7B5C' ) );
-				$color_white                   = sanitize_hex_color( '#FFFFFF' );
-				$border_color                  = sanitize_hex_color( get_theme_mod( 'border_color', '#E2E8F0' ) );
-				$footer_top_bg                 = sanitize_hex_color( get_theme_mod( 'footer_top_bg', '#1E3A5F' ) );
-				$selection_bg                  = sanitize_hex_color( get_theme_mod( 'selection_bg', '#1E3A5F' ) );
-		$icon_color                            = sanitize_hex_color( get_theme_mod( 'icon_color', '#0B1426' ) );
-		$toc_link                              = sanitize_hex_color( get_theme_mod( 'toc_link', '#0F7B5C' ) );
-		$category_bg                           = sanitize_hex_color( get_theme_mod( 'category_bg', '#0F7B5C' ) );
-		$category_bg_hover                     = sanitize_hex_color( get_theme_mod( 'category_bg_hover', '#1E3A5F' ) );
-		$category_text                         = sanitize_hex_color( get_theme_mod( 'category_text', '#FFFFFF' ) );
-		$category_text_hover                   = sanitize_hex_color( get_theme_mod( 'category_text_hover', '#FFFFFF' ) );
-		$modal_border                          = sanitize_hex_color( '#64748B' );
+        $dynamic_css = smile_web_get_dynamic_css_variables();
 
-		$dynamic_css = '
-                :root {
-                        --link: ' . esc_attr( $link_default ) . ';
-                        --link-hover: ' . esc_attr( $link_hover ) . ';
-                        --link-active: ' . esc_attr( $link_active ) . ';
-                        --link-visited: ' . esc_attr( $link_visited ) . ';
-                        --comment-color: ' . esc_attr( $comment_color ) . ';
-                        --card-text-color: ' . esc_attr( $card_text_color ) . ';
-                        --color-warning: ' . esc_attr( $color_warning ) . ';
-                        --cta-bg: ' . esc_attr( $cta_bg ) . ';
-                        --breadcrumb-separator: "' . esc_attr( $breadcrumb_separator ) . '";
-                        --text-base: ' . esc_attr( $text_base ) . ';
-                        --text-muted: ' . esc_attr( $text_muted ) . ';
-                        --text-heading: ' . esc_attr( $text_heading ) . ';
-                        --text-subheading: ' . esc_attr( $text_subheading ) . ';
-                        --text-emphasis: ' . esc_attr( $text_emphasis ) . ';
-                        --text-quote: ' . esc_attr( $text_quote ) . ';
-                        --text-list: ' . esc_attr( $text_list ) . ';
-                        --accent-primary-light: ' . esc_attr( $accent_primary_light ) . ';
-                        --accent-primary: ' . esc_attr( $accent_primary ) . ';
-                        --accent-secondary: ' . esc_attr( $accent_secondary ) . ';
-                        --accent-secondary-dark: ' . esc_attr( $accent_secondary_dark ) . ';
-                        --color-white: ' . esc_attr( $color_white ) . ';
-                        --bg-primary: ' . esc_attr( $bg_primary ) . ';
-                        --bg-secondary: ' . esc_attr( $bg_secondary ) . ';
-                        --breadcrumb-bg: ' . esc_attr( $breadcrumb_bg ) . ';
-                        --front-intro-overlay: ' . esc_attr( $front_intro_overlay ) . ';
-                        --front-intro-heading: ' . esc_attr( $front_intro_heading ) . ';
-                        --front-intro-text: ' . esc_attr( $front_intro_text ) . ';
-                        --page-intro-bg: ' . esc_attr( $page_intro_bg ) . ';
-                        --page-intro-heading: ' . esc_attr( $page_intro_heading ) . ';
-                        --single-intro-bg: ' . esc_attr( $single_intro_bg ) . ';
-                        --single-intro-heading: ' . esc_attr( $single_intro_heading ) . ';
-                        --btn-text: ' . esc_attr( $button_text ) . ';
-                        --btn-text-hover: ' . esc_attr( $button_text_hover ) . ';
-                        --btn-bg: ' . esc_attr( $button_bg ) . ';
-                        --btn-bg-hover: ' . esc_attr( $button_bg_hover ) . ';
-                        --btn-border: ' . esc_attr( $button_border ) . ';
-                        --btn-border-hover: ' . esc_attr( $button_border_hover ) . ';
-                        --form-text: ' . esc_attr( $form_text ) . ';
-                        --form-placeholder: ' . esc_attr( $form_placeholder ) . ';
-                        --form-border: ' . esc_attr( $form_border ) . ';
-                        --form-border-focus: ' . esc_attr( $form_border_focus ) . ';
-                        --form-bg: ' . esc_attr( $form_bg ) . ';
-                        --form-error: ' . esc_attr( $form_error ) . ';
-                        --form-success: ' . esc_attr( $form_success ) . ';
-                        --alert-success: ' . esc_attr( $alert_success ) . ';
-                        --alert-error: ' . esc_attr( $alert_error ) . ';
-                        --alert-warning: ' . esc_attr( $alert_warning ) . ';
-                        --alert-info: ' . esc_attr( $alert_info ) . ';
-                        --topbar-bg: ' . esc_attr( $topbar_bg ) . ';
-                        --topbar-text: ' . esc_attr( $topbar_text ) . ';
-                        --topbar-link: ' . esc_attr( $topbar_link ) . ';
-                        --topbar-link-hover: ' . esc_attr( $topbar_link_hover ) . ';
-                        --topbar-social-icon: ' . esc_attr( $topbar_social_icon ) . ';
-                        --masthead-bg: ' . esc_attr( $masthead_bg ) . ';
-                        --masthead-submenu-bg: ' . esc_attr( $masthead_submenu_bg ) . ';
-                        --masthead-submenu-text: ' . esc_attr( $masthead_submenu_text ) . ';
-                        --masthead-text: ' . esc_attr( $masthead_text ) . ';
-                        --masthead-link: ' . esc_attr( $masthead_link ) . ';
-                        --masthead-link-hover: ' . esc_attr( $masthead_link_hover ) . ';
-                        --masthead-scrolled-bg: ' . esc_attr( $masthead_scrolled_bg ) . ';
-                        --footer-bg: ' . esc_attr( $footer_bg ) . ';
-                        --footer-text: ' . esc_attr( $footer_text ) . ';
-                        --footer-link: ' . esc_attr( $footer_link ) . ';
-                        --footer-link-hover: ' . esc_attr( $footer_link_hover ) . ';
-                        --footer-border: ' . esc_attr( $footer_border ) . ';
-                        --footer-social-bg: ' . esc_attr( $footer_social_bg ) . ';
-                        --footer-social-icon: ' . esc_attr( $footer_social_icon ) . ';
-                        --footer-social-icon-hover: ' . esc_attr( $footer_social_icon_hover ) . ';
-                        --border: ' . esc_attr( $border_color ) . ';
-                        --footer-top-bg: ' . esc_attr( $footer_top_bg ) . ';
-                        --selection-bg: ' . esc_attr( $selection_bg ) . ';
-                        --icon: ' . esc_attr( $icon_color ) . ';
-                        --category-bg: ' . esc_attr( $category_bg ) . ';
-                        --category-bg-hover: ' . esc_attr( $category_bg_hover ) . ';
-                        --category-text: ' . esc_attr( $category_text ) . ';
-                        --category-text-hover: ' . esc_attr( $category_text_hover ) . ';
-                        --toc-link: ' . esc_attr( $toc_link ) . ';
-                        --modal-border: ' . esc_attr( $modal_border ) . ';
-                }
-        ';
+        if ( empty( $dynamic_css ) ) {
+                return;
+        }
 
-	// Se agrega el CSS en línea al handle 'smile-web-main'.
-	wp_add_inline_style( 'smile-web-main', $dynamic_css );
+        // Se agrega el CSS en línea al handle 'smile-web-main'.
+        wp_add_inline_style( 'smile-web-main', $dynamic_css );
 }
 add_action( 'wp_enqueue_scripts', 'smile_web_add_dynamic_styles' );
+
+/**
+ * Enqueues the dynamic CSS variables for the block editor.
+ */
+function smile_web_add_editor_dynamic_styles() {
+        $dynamic_css = smile_web_get_dynamic_css_variables();
+
+        if ( ! empty( $dynamic_css ) ) {
+                wp_add_inline_style( 'wp-edit-blocks', $dynamic_css );
+        }
+
+        $preset_css = smile_web_get_theme_preset_root_css();
+
+        if ( ! empty( $preset_css ) ) {
+                wp_add_inline_style( 'wp-edit-blocks', $preset_css );
+        }
+}
+add_action( 'enqueue_block_editor_assets', 'smile_web_add_editor_dynamic_styles' );
 
 /**
  * Outputs custom CSS stored via the Customizer.
  */
 function smile_v6_custom_css_output() {
-	$custom_css = wp_get_custom_css();
-	if ( ! empty( $custom_css ) ) {
-		echo '<style type="text/css">' . esc_html( wp_strip_all_tags( $custom_css ) ) . '</style>';
-	}
+        $custom_css = wp_get_custom_css();
+
+        if ( ! empty( $custom_css ) ) {
+                echo '<style type="text/css">' . esc_html( wp_strip_all_tags( $custom_css ) ) . '</style>';
+        }
 }
 add_action( 'wp_head', 'smile_v6_custom_css_output' );

--- a/inc/theme-setup.php
+++ b/inc/theme-setup.php
@@ -24,7 +24,9 @@ function smile_v6_setup() {
 	add_theme_support( 'automatic-feed-links' );
 	add_theme_support( 'title-tag' );
 	add_theme_support( 'post-thumbnails' );
-	add_theme_support( 'appearance-tools' );
+        add_theme_support( 'appearance-tools' );
+        add_theme_support( 'editor-styles' );
+        add_editor_style( 'assets/css/editor-style.css' );
 
 	// Register nav menus.
 	register_nav_menus(
@@ -66,6 +68,104 @@ function smile_v6_setup() {
 	);
 }
 add_action( 'after_setup_theme', 'smile_v6_setup' );
+
+/**
+ * Extracts the :root block that contains WordPress preset variables.
+ *
+ * @param string $css CSS string to inspect.
+ * @return string CSS limited to the :root block with preset variables.
+ */
+function smile_web_extract_theme_preset_root_css( $css ) {
+        if ( empty( $css ) || ! is_string( $css ) ) {
+                return '';
+        }
+
+        $matches = array();
+        preg_match_all( '/:root\s*\{[^}]*\}/', $css, $matches );
+
+        if ( empty( $matches[0] ) ) {
+                return '';
+        }
+
+        $blocks = array();
+
+        foreach ( $matches[0] as $block ) {
+                if ( false !== strpos( $block, '--wp--preset--' ) ) {
+                        $blocks[] = trim( $block );
+                }
+        }
+
+        if ( empty( $blocks ) ) {
+                return '';
+        }
+
+        return implode( "\n", $blocks ) . "\n";
+}
+
+/**
+ * Retrieves the preset variables generated from theme.json for reuse.
+ *
+ * @param string $fallback_css Optional CSS to parse if global styles are unavailable.
+ * @return string CSS containing the :root preset declarations.
+ */
+function smile_web_get_theme_preset_root_css( $fallback_css = '' ) {
+        $css_candidates = array();
+
+        if ( function_exists( 'wp_get_global_stylesheet' ) ) {
+                $css_candidates[] = wp_get_global_stylesheet( array( 'presets' ) );
+        }
+
+        if ( ! empty( $fallback_css ) ) {
+                $css_candidates[] = $fallback_css;
+        }
+
+        foreach ( $css_candidates as $candidate_css ) {
+                $preset_css = smile_web_extract_theme_preset_root_css( $candidate_css );
+
+                if ( ! empty( $preset_css ) ) {
+                        return $preset_css;
+                }
+        }
+
+        return '';
+}
+
+/**
+ * Removes the theme.json-generated styles from the block editor settings.
+ *
+ * This keeps the front-end benefits of theme.json while restoring the classic
+ * editor appearance by preventing the block editor from enqueueing the theme
+ * styles automatically derived from theme.json.
+ *
+ * @param array $settings Block editor settings.
+ * @return array Filtered block editor settings.
+ */
+function smile_web_remove_theme_json_editor_styles( $settings ) {
+        if ( empty( $settings['styles'] ) || ! is_array( $settings['styles'] ) ) {
+                return $settings;
+        }
+
+        $filtered_styles = array();
+
+        foreach ( $settings['styles'] as $style ) {
+                if ( isset( $style['__unstableType'] ) && 'theme' === $style['__unstableType'] ) {
+                        $preset_css = smile_web_get_theme_preset_root_css( isset( $style['css'] ) ? $style['css'] : '' );
+
+                        if ( empty( $preset_css ) ) {
+                                continue;
+                        }
+
+                        $style['css'] = $preset_css;
+                }
+
+                $filtered_styles[] = $style;
+        }
+
+        $settings['styles'] = array_values( $filtered_styles );
+
+        return $settings;
+}
+add_filter( 'block_editor_settings_all', 'smile_web_remove_theme_json_editor_styles' );
 
 /**
  * Automatically sets up default menus when the theme is activated.


### PR DESCRIPTION
## Summary
- preserve the theme.json-generated preset CSS variables when filtering editor styles so block padding and spacing variables remain available
- inject the extracted preset variables alongside the existing dynamic CSS when loading the block editor to keep editor-style.css functional

## Testing
- php -l inc/theme-setup.php
- php -l inc/customizer-dynamic-styles.php

------
https://chatgpt.com/codex/tasks/task_e_68ca8a7528f083309f0722413e85e353