### PR TITLE
Allow block editor to use theme styles

### DIFF
--- a/inc/theme-setup.php
+++ b/inc/theme-setup.php
@@ -70,34 +70,6 @@ function smile_v6_setup() {
 add_action( 'after_setup_theme', 'smile_v6_setup' );
 
 /**
- * Removes the theme.json-generated styles from the block editor settings.
- *
- * This keeps the front-end benefits of theme.json while restoring the classic
- * editor appearance by preventing the block editor from enqueueing the theme
- * styles automatically derived from theme.json.
- *
- * @param array $settings Block editor settings.
- * @return array Filtered block editor settings.
- */
-function smile_web_remove_theme_json_editor_styles( $settings ) {
-        if ( empty( $settings['styles'] ) || ! is_array( $settings['styles'] ) ) {
-                return $settings;
-        }
-
-        $settings['styles'] = array_values(
-                array_filter(
-                        $settings['styles'],
-                        function ( $style ) {
-                                return ! ( isset( $style['__unstableType'] ) && 'theme' === $style['__unstableType'] );
-                        }
-                )
-        );
-
-        return $settings;
-}
-add_filter( 'block_editor_settings_all', 'smile_web_remove_theme_json_editor_styles' );
-
-/**
  * Automatically sets up default menus when the theme is activated.
  */
 function smile_v6_setup_default_menus() {


### PR DESCRIPTION
## Summary
- remove the block editor settings filter so theme.json styles can load in the editor

## Testing
- php -l inc/theme-setup.php

------
https://chatgpt.com/codex/tasks/task_e_68caa64657fc8330a25b5fd96d5235e5