### PR TITLE
Ensure block editor loads theme styling

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -220,13 +220,36 @@ add_action( 'wp_enqueue_scripts', 'smile_web_add_dynamic_styles' );
  * Enqueues the dynamic CSS variables for the block editor.
  */
 function smile_web_add_editor_dynamic_styles() {
+        $theme_version = defined( '_S_VERSION' ) ? _S_VERSION : '1.0.0';
+
+        wp_enqueue_style(
+                'smile-web-editor-base',
+                get_stylesheet_uri(),
+                array(),
+                $theme_version
+        );
+
+        wp_enqueue_style(
+                'smile-web-editor-main',
+                get_template_directory_uri() . '/assets/css/main.css',
+                array( 'smile-web-editor-base' ),
+                $theme_version
+        );
+
+        wp_enqueue_style(
+                'smile-web-editor',
+                get_template_directory_uri() . '/assets/css/editor-style.css',
+                array( 'smile-web-editor-main' ),
+                $theme_version
+        );
+
         $dynamic_css = smile_web_get_dynamic_css_variables();
 
         if ( empty( $dynamic_css ) ) {
                 return;
         }
 
-        wp_add_inline_style( 'wp-edit-blocks', $dynamic_css );
+        wp_add_inline_style( 'smile-web-editor', $dynamic_css );
 }
 add_action( 'enqueue_block_editor_assets', 'smile_web_add_editor_dynamic_styles' );
 

--- a/inc/theme-setup.php
+++ b/inc/theme-setup.php
@@ -26,7 +26,13 @@ function smile_v6_setup() {
 	add_theme_support( 'post-thumbnails' );
         add_theme_support( 'appearance-tools' );
         add_theme_support( 'editor-styles' );
-        add_editor_style( 'assets/css/editor-style.css' );
+        add_editor_style(
+                array(
+                        'assets/css/editor-style.css',
+                        'style.css',
+                        'assets/css/main.css',
+                )
+        );
 
 	// Register nav menus.
 	register_nav_menus(


### PR DESCRIPTION
## Summary
- load the front-end theme styles inside the editor styles declaration so utility classes are available in Gutenberg
- enqueue a dedicated `smile-web-editor` stylesheet in the block editor and attach the dynamic CSS variables to it

## Testing
- php -l inc/theme-setup.php
- php -l inc/customizer-dynamic-styles.php

------
https://chatgpt.com/codex/tasks/task_e_68caa6bd67a8833099ea6d0d88b749b1