### PR TITLE
Configure editor layout widths

### DIFF
--- a/assets/css/editor-style.css
+++ b/assets/css/editor-style.css
@@ -4,6 +4,26 @@ body .editor-styles-wrapper {
     color: var(--text-base);
     background-color: #ffffff;
 }
+
+.editor-styles-wrapper .block-editor-block-list__layout.is-root-container {
+    width: 95%;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.editor-styles-wrapper .block-editor-block-list__layout.is-root-container > .alignwide {
+    width: min(95vw, 1320px);
+    max-width: 1320px;
+    margin-left: calc(50% - min(95vw, 1320px) / 2);
+    margin-right: calc(50% - min(95vw, 1320px) / 2);
+}
+
+.editor-styles-wrapper .block-editor-block-list__layout.is-root-container > .alignfull {
+    width: 100vw;
+    max-width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+}
 @font-face {
     font-family: 'Roboto Bold';
     src: url('fonts/Roboto-Bold.ttf') format('truetype');

--- a/theme.json
+++ b/theme.json
@@ -1,6 +1,10 @@
 {
   "version": 2,
   "settings": {
+    "layout": {
+      "contentSize": "1000px",
+      "wideSize": "1320px"
+    },
     "typography": {
       "fluid": true,
       "fontSizes": [


### PR DESCRIPTION
## Summary
- define theme layout widths that match the front-end container sizing
- mirror the front-end container, wide, and full alignment widths inside the block editor

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cab6ef74988330bfc1e61db04767ab