### PR TITLE
Remove block editor custom styles support

### DIFF
--- a/inc/theme-setup.php
+++ b/inc/theme-setup.php
@@ -23,16 +23,7 @@ function smile_v6_setup() {
 
 	add_theme_support( 'automatic-feed-links' );
 	add_theme_support( 'title-tag' );
-	add_theme_support( 'post-thumbnails' );
-        add_theme_support( 'appearance-tools' );
-        add_theme_support( 'editor-styles' );
-        add_editor_style(
-                array(
-                        'assets/css/editor-style.css',
-                        'style.css',
-                        'assets/css/main.css',
-                )
-        );
+        add_theme_support( 'post-thumbnails' );
 
 	// Register nav menus.
 	register_nav_menus(


### PR DESCRIPTION
## Summary
- remove appearance tools and custom editor styles from the theme setup so the editor falls back to WordPress defaults

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cad2d8890c83309bbb69a27ee8aa7b