### PR TITLE
Restore classic editor stylesheet

### DIFF
--- a/assets/css/editor-style.css
+++ b/assets/css/editor-style.css
@@ -4,26 +4,6 @@ body .editor-styles-wrapper {
     color: var(--text-base);
     background-color: #ffffff;
 }
-
-.editor-styles-wrapper .block-editor-block-list__layout.is-root-container {
-    width: 95%;
-    max-width: 1000px;
-    margin: 0 auto;
-}
-
-.editor-styles-wrapper .block-editor-block-list__layout.is-root-container > .alignwide {
-    width: min(95vw, 1320px);
-    max-width: 1320px;
-    margin-left: calc(50% - min(95vw, 1320px) / 2);
-    margin-right: calc(50% - min(95vw, 1320px) / 2);
-}
-
-.editor-styles-wrapper .block-editor-block-list__layout.is-root-container > .alignfull {
-    width: 100vw;
-    max-width: 100vw;
-    margin-left: calc(50% - 50vw);
-    margin-right: calc(50% - 50vw);
-}
 @font-face {
     font-family: 'Roboto Bold';
     src: url('fonts/Roboto-Bold.ttf') format('truetype');


### PR DESCRIPTION
## Summary
- replace the block editor stylesheet with the pre-theme.json version so container width and alignment rules are no longer applied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbaecdfff88330a95461363a202b98