### PR TITLE
Add WordPress caption and alignment styles

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -120,7 +120,55 @@ body {
 }
 
 ::selection {
-	background-color: var(--selection-bg);
+        background-color: var(--selection-bg);
+}
+
+
+.wp-caption {
+        max-width: 100%;
+        margin: 0 0 1.5em;
+        text-align: center;
+}
+
+.wp-caption img {
+        display: block;
+        margin: 0 auto;
+        height: auto;
+}
+
+.wp-caption-text,
+.gallery-caption {
+        margin-top: 0.5em;
+        font-size: 0.875em;
+        color: var(--text-subheading);
+}
+
+.bypostauthor {
+        border-right: 4px solid var(--accent-secondary-dark);
+        padding-right: 1rem;
+        font-weight: 600;
+}
+
+.sticky {
+        border-right: 4px solid var(--accent-secondary-dark);
+        padding: 1.5rem;
+        background-color: var(--accent-primary-light);
+}
+
+.alignleft {
+        float: right;
+        margin: 0 0 1.5em 1.5em;
+}
+
+.alignright {
+        float: left;
+        margin: 0 1.5em 1.5em 0;
+}
+
+.aligncenter {
+        display: block;
+        margin: 0 auto 1.5em;
+        text-align: center;
 }
 
 

--- a/style.css
+++ b/style.css
@@ -120,7 +120,55 @@ body {
 }
 
 ::selection {
-	background-color: var(--selection-bg);
+        background-color: var(--selection-bg);
+}
+
+
+.wp-caption {
+        max-width: 100%;
+        margin: 0 0 1.5em;
+        text-align: center;
+}
+
+.wp-caption img {
+        display: block;
+        margin: 0 auto;
+        height: auto;
+}
+
+.wp-caption-text,
+.gallery-caption {
+        margin-top: 0.5em;
+        font-size: 0.875em;
+        color: var(--text-subheading);
+}
+
+.bypostauthor {
+        border-left: 4px solid var(--accent-secondary-dark);
+        padding-left: 1rem;
+        font-weight: 600;
+}
+
+.sticky {
+        border-left: 4px solid var(--accent-secondary-dark);
+        padding: 1.5rem;
+        background-color: var(--accent-primary-light);
+}
+
+.alignleft {
+        float: left;
+        margin: 0 1.5em 1.5em 0;
+}
+
+.alignright {
+        float: right;
+        margin: 0 0 1.5em 1.5em;
+}
+
+.aligncenter {
+        display: block;
+        margin: 0 auto 1.5em;
+        text-align: center;
 }
 
 


### PR DESCRIPTION
## Summary
- add baseline styles for WordPress caption containers, caption text, sticky posts, and alignment helper classes in the main stylesheet
- mirror the new WordPress helper rules in the RTL stylesheet to maintain parity

## Testing
- `npx @wordpress/theme-check .` *(fails: package `@wordpress/theme-check` not found in npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cc025037dc83309f998d1ad2f027ca