### PR TITLE
Enable responsive embed and align-wide support

### DIFF
--- a/inc/theme-setup.php
+++ b/inc/theme-setup.php
@@ -26,6 +26,8 @@ function smile_v6_setup() {
         add_theme_support( 'post-thumbnails' );
         add_theme_support( 'appearance-tools' );
         add_theme_support( 'editor-styles' );
+        add_theme_support( 'responsive-embeds' );
+        add_theme_support( 'align-wide' );
         add_editor_style( 'assets/css/editor-style.css' );
 
 	// Register nav menus.


### PR DESCRIPTION
## Summary
- add block editor support for responsive embeds
- enable wide and full alignment options

## Testing
- npx @wordpress/theme-check . *(fails: package @wordpress/theme-check not found in npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0f73ca3c83309e171995d7eff15e