### PR TITLE
Add block styles support

### DIFF
--- a/inc/theme-setup.php
+++ b/inc/theme-setup.php
@@ -25,7 +25,8 @@ function smile_v6_setup() {
 	add_theme_support( 'title-tag' );
         add_theme_support( 'post-thumbnails' );
         add_theme_support( 'appearance-tools' );
-        add_theme_support( 'editor-styles' );
+add_theme_support( 'editor-styles' );
+add_theme_support( 'wp-block-styles' );
         add_theme_support( 'responsive-embeds' );
         add_theme_support( 'align-wide' );
         add_editor_style( 'assets/css/editor-style.css' );


### PR DESCRIPTION
## Summary
- enable WordPress block styles support in the theme setup function

## Testing
- npx theme-check --help *(fails: npm could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68cc134f36f08330baccc1023ff326d3