### PR TITLE
Add custom block styles

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -58,6 +58,12 @@ require get_template_directory() . '/inc/widgets.php';
 require get_template_directory() . '/inc/block-patterns.php';
 
 /**
+ * Incluye los estilos de bloques.
+ * Registra estilos adicionales para bloques que aprovechan las utilidades del tema.
+ */
+require get_template_directory() . '/inc/block-styles.php';
+
+/**
  * Incluye la configuración del encabezado personalizado.
  * Contiene funciones relacionadas con la funcionalidad del encabezado (custom header).
  */

--- a/inc/block-styles.php
+++ b/inc/block-styles.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Block Styles Registration for SMiLE Web Theme.
+ *
+ * @package smile-web
+ */
+
+if ( ! function_exists( 'smile_v6_register_block_styles' ) ) {
+        /**
+         * Registers additional block styles that expose theme utility classes.
+         *
+         * @return void
+         */
+        function smile_v6_register_block_styles() {
+                if ( ! function_exists( 'register_block_style' ) ) {
+                        return;
+                }
+
+                register_block_style(
+                        'core/image',
+                        array(
+                                'name'         => 'smile-shadow',
+                                'label'        => __( 'Sombra suave', 'smile-web' ),
+                                'style_handle' => 'smile-web-style',
+                        )
+                );
+
+                register_block_style(
+                        'core/quote',
+                        array(
+                                'name'         => 'smile-accent-border',
+                                'label'        => __( 'Borde destacado', 'smile-web' ),
+                                'style_handle' => 'smile-web-style',
+                        )
+                );
+        }
+}
+add_action( 'init', 'smile_v6_register_block_styles' );

--- a/style.css
+++ b/style.css
@@ -1978,7 +1978,23 @@ ol.wp-block-list {
 }
 
 .g-0 {
-	gap: 0;
+        gap: 0;
+}
+
+/* Gutenberg Block Styles */
+.wp-block-image.is-style-smile-shadow img {
+        box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .15) !important;
+}
+
+.wp-block-quote.is-style-smile-accent-border {
+        border-left: 4px solid var(--accent-secondary-dark);
+        padding: 1.5rem;
+        background-color: var(--accent-primary-light);
+        color: var(--text-quote);
+}
+
+.wp-block-quote.is-style-smile-accent-border cite {
+        color: var(--text-subheading);
 }
 
 /* ------------------------------------------


### PR DESCRIPTION
## Summary
- register custom block styles for image and quote blocks in a dedicated include
- load the new block styles include from the theme bootstrap
- add Gutenberg block CSS that maps to the registered styles

## Testing
- npx @wordpress/theme-check --theme . *(fails: package not available in npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1578870c833096d7f30cfbe56618