### PR TITLE
Add appearance customizer controls for buttons and WhatsApp offset

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -290,8 +290,8 @@ blockquote {
 	--------------------------------------------------------------*/
 .whatsapp-button {
 	position: fixed;
-	right: 15px;
-	bottom: 15px;
+	right: var(--whatsapp-offset-right, 15px);
+	bottom: var(--whatsapp-offset-bottom, 15px);
 	z-index: 101;
 }
 

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -57,8 +57,11 @@ function smile_web_get_dynamic_root_styles() {
 				$button_text_hover             = sanitize_hex_color( get_theme_mod( 'button_text_hover', '#0F7B5C' ) );
 				$button_bg                     = sanitize_hex_color( get_theme_mod( 'button_bg', '#0F7B5C' ) );
 				$button_bg_hover               = sanitize_hex_color( get_theme_mod( 'button_bg_hover', '#FFFFFF' ) );
-				$button_border                 = sanitize_hex_color( get_theme_mod( 'button_border', '#0F7B5C' ) );
-				$button_border_hover           = sanitize_hex_color( get_theme_mod( 'button_border_hover', '#0F7B5C' ) );
+                $button_border                 = sanitize_hex_color( get_theme_mod( 'button_border', '#0F7B5C' ) );
+                $button_border_hover           = sanitize_hex_color( get_theme_mod( 'button_border_hover', '#0F7B5C' ) );
+                $button_border_radius          = absint( get_theme_mod( 'button_border_radius', 50 ) ) . 'px';
+                $whatsapp_button_offset_right  = absint( get_theme_mod( 'whatsapp_button_offset_right', 15 ) ) . 'px';
+                $whatsapp_button_offset_bottom = absint( get_theme_mod( 'whatsapp_button_offset_bottom', 15 ) ) . 'px';
 				$form_text                     = sanitize_hex_color( get_theme_mod( 'form_text', '#1A202C' ) );
 				$form_placeholder              = sanitize_hex_color( get_theme_mod( 'form_placeholder', '#64748B' ) );
 				$form_border                   = sanitize_hex_color( get_theme_mod( 'form_border', '#E2E8F0' ) );
@@ -141,6 +144,9 @@ function smile_web_get_dynamic_root_styles() {
                         --btn-bg-hover: ' . esc_attr( $button_bg_hover ) . ';
                         --btn-border: ' . esc_attr( $button_border ) . ';
                         --btn-border-hover: ' . esc_attr( $button_border_hover ) . ';
+                        --btn-radius: ' . esc_attr( $button_border_radius ) . ';
+                        --whatsapp-offset-right: ' . esc_attr( $whatsapp_button_offset_right ) . ';
+                        --whatsapp-offset-bottom: ' . esc_attr( $whatsapp_button_offset_bottom ) . ';
                         --form-text: ' . esc_attr( $form_text ) . ';
                         --form-placeholder: ' . esc_attr( $form_placeholder ) . ';
                         --form-border: ' . esc_attr( $form_border ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -200,6 +200,109 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 		)
 	);
 
+		// Add Theme Appearance panel.
+		$wp_customize->add_panel(
+			'smile_theme_appearance',
+			array(
+				'title'      => esc_html__( 'Theme Appearance', 'smile-web' ),
+				'priority'   => 40,
+				'capability' => 'edit_theme_options',
+			)
+		);
+
+		// Add Buttons subsection.
+		$wp_customize->add_section(
+			'smile_theme_buttons',
+			array(
+				'title'      => esc_html__( 'Buttons', 'smile-web' ),
+				'priority'   => 10,
+				'capability' => 'edit_theme_options',
+				'panel'      => 'smile_theme_appearance',
+			)
+		);
+
+		// Add Floating Elements subsection.
+		$wp_customize->add_section(
+			'smile_theme_floating_elements',
+			array(
+				'title'      => esc_html__( 'Floating Elements', 'smile-web' ),
+				'priority'   => 20,
+				'capability' => 'edit_theme_options',
+				'panel'      => 'smile_theme_appearance',
+			)
+		);
+
+		// Button radius setting and control.
+		$wp_customize->add_setting(
+			'button_border_radius',
+			array(
+				'default'           => 50,
+				'sanitize_callback' => 'absint',
+			)
+		);
+
+		$wp_customize->add_control(
+			'button_border_radius',
+			array(
+				'label'       => esc_html__( 'Button Border Radius', 'smile-web' ),
+				'description' => esc_html__( 'Adjust the roundness of buttons. Default: 50px.', 'smile-web' ),
+				'section'     => 'smile_theme_buttons',
+				'type'        => 'number',
+				'input_attrs' => array(
+					'min'  => 0,
+					'max'  => 200,
+					'step' => 1,
+				),
+			)
+		);
+
+		// Floating WhatsApp button offset settings and controls.
+		$wp_customize->add_setting(
+			'whatsapp_button_offset_right',
+			array(
+				'default'           => 15,
+				'sanitize_callback' => 'absint',
+			)
+		);
+
+		$wp_customize->add_control(
+			'whatsapp_button_offset_right',
+			array(
+				'label'       => esc_html__( 'WhatsApp Button Offset (Right)', 'smile-web' ),
+				'description' => esc_html__( 'Control the horizontal distance from the edge. Default: 15px.', 'smile-web' ),
+				'section'     => 'smile_theme_floating_elements',
+				'type'        => 'number',
+				'input_attrs' => array(
+					'min'  => 0,
+					'max'  => 200,
+					'step' => 1,
+				),
+			)
+		);
+
+		$wp_customize->add_setting(
+			'whatsapp_button_offset_bottom',
+			array(
+				'default'           => 15,
+				'sanitize_callback' => 'absint',
+			)
+		);
+
+		$wp_customize->add_control(
+			'whatsapp_button_offset_bottom',
+			array(
+				'label'       => esc_html__( 'WhatsApp Button Offset (Bottom)', 'smile-web' ),
+				'description' => esc_html__( 'Control the vertical distance from the edge. Default: 15px.', 'smile-web' ),
+				'section'     => 'smile_theme_floating_elements',
+				'type'        => 'number',
+				'input_attrs' => array(
+					'min'  => 0,
+					'max'  => 200,
+					'step' => 1,
+				),
+			)
+		);
+
 		// Add theme settings section.
 	$wp_customize->add_section(
 		'smile_v6_settings',

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -293,7 +293,7 @@ a:visited:not([class*="btn"]):not([class*="button"]) {
 .btn {
 	display: inline-block;
 	z-index: 100;
-	border-radius: 50px;
+	border-radius: var(--btn-radius, 50px);
 	transition: .5s;
 	margin: 5px;
 	font-weight: 500;
@@ -341,7 +341,7 @@ a:visited:not([class*="btn"]):not([class*="button"]) {
 	z-index: 100;
 	padding: 6px;
 	margin: 10px;
-	border-radius: 50px;
+	border-radius: var(--btn-radius, 50px);
 	color: var(--color-white);
 	background-color: var(--accent-secondary-dark);
 	text-decoration: none;

--- a/style.css
+++ b/style.css
@@ -293,7 +293,7 @@ a:visited:not([class*="btn"]):not([class*="button"]) {
 .btn {
 	display: inline-block;
 	z-index: 100;
-	border-radius: 50px;
+	border-radius: var(--btn-radius, 50px);
 	transition: .5s;
 	margin: 5px;
 	font-weight: 500;
@@ -341,7 +341,7 @@ a:visited:not([class*="btn"]):not([class*="button"]) {
 	z-index: 100;
 	padding: 6px;
 	margin: 10px;
-	border-radius: 50px;
+	border-radius: var(--btn-radius, 50px);
 	color: var(--color-white);
 	background-color: var(--accent-secondary-dark);
 	text-decoration: none;


### PR DESCRIPTION
## Summary
- add a Theme Appearance panel with button and floating element controls in the Customizer
- expose button radius and WhatsApp offsets as CSS variables consumed by theme styles

## Testing
- php -l inc/customizer-options.php
- php -l inc/customizer-dynamic-styles.php

------
https://chatgpt.com/codex/tasks/task_e_68cd25a88194833090b5623d48b918b9