### PR TITLE
Update related post thumbnails on single template

### DIFF
--- a/single.php
+++ b/single.php
@@ -193,30 +193,39 @@ get_header();
 			<br>
 			<div class="row">
 				<?php
-				$recent = new WP_Query( $args );
-				while ( $recent->have_posts() ) :
-					$recent->the_post();
-					?>
-				<article class="blog-col col-md-4 col-sm-6 mb-4 mx-0">
-					<figure class="mb-0 shadow">
-						<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
-							<?php
-							if ( has_post_thumbnail() ) {
-								$attachment_id = get_post_thumbnail_id( get_the_ID() );
-								$metadata      = wp_get_attachment_metadata( $attachment_id );
-								$height        = $metadata['height'];
-								$width         = $metadata['width'];
-								$alt           = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
-								$image_title   = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_title', true ) ) );
-								$src           = wp_get_attachment_url( $attachment_id );
-								echo '<img src="' . esc_url( $src ) . '" height="' . esc_attr( $height ) . '" width="' . esc_attr( $width ) . '" alt="' . esc_attr( $alt ) . '" title="' . esc_attr( $image_title ) . '">';
-							} else {
-								?>
-							<img src="<?php echo esc_url( get_template_directory_uri() ); ?>/img/thumbnail-article.jpg" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" width="1000px" height="667px">
-								<?php
-							}
-							?>
-						</a>
+                                $recent = new WP_Query( $args );
+                                $blog_post_default_img = get_theme_mod( 'blog_default_image', '' );
+
+                                while ( $recent->have_posts() ) :
+                                        $recent->the_post();
+                                        ?>
+                                <article class="blog-col col-md-4 col-sm-6 mb-4 mx-0">
+                                        <figure class="mb-0 shadow">
+                                                <a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
+                                                        <?php
+                                                        if ( has_post_thumbnail() ) {
+                                                                $thumb_url = get_the_post_thumbnail_url( get_the_ID(), 'medium' );
+                                                                $thumb_id  = get_post_thumbnail_id();
+                                                                $thumb_alt = get_post_meta( $thumb_id, '_wp_attachment_image_alt', true );
+
+                                                                if ( empty( $thumb_alt ) ) {
+                                                                        $thumb_alt = get_the_title();
+                                                                }
+                                                        } elseif ( ! empty( $blog_post_default_img ) ) {
+                                                                $thumb_url = $blog_post_default_img;
+                                                                $thumb_alt = get_bloginfo( 'name' );
+                                                        } else {
+                                                                $thumb_url = get_template_directory_uri() . '/assets/img/thumbnail-header.jpg';
+                                                                $thumb_alt = get_bloginfo( 'name' );
+                                                        }
+
+                                                        printf(
+                                                                '<img src="%1$s" class="img-fluid" alt="%2$s" width="1000" height="667" />',
+                                                                esc_url( $thumb_url ),
+                                                                esc_attr( $thumb_alt )
+                                                        );
+                                                        ?>
+                                                </a>
 						<figcaption id="post-<?php the_ID(); ?>" class="p-4">
 							<h4><a href="<?php the_permalink(); ?>" rel="bookmark" title="<?php echo esc_attr( get_the_title() ); ?>"><?php the_title(); ?></a></h4>
 							<p><?php the_excerpt(); ?></p>


### PR DESCRIPTION
## Summary
- update the related posts loop in `single.php` to mirror the thumbnail fallback logic used on the front page
- load the customizer default image when no featured image exists and fall back to the theme asset otherwise
- ensure the thumbnail alt text matches the attachment metadata or site name based on the chosen image

## Testing
- php -l single.php

------
https://chatgpt.com/codex/tasks/task_e_68cd31606b4083309d5049190f1ff621