### PR TITLE
Adjust entry content layout for single posts

### DIFF
--- a/style.css
+++ b/style.css
@@ -1952,8 +1952,14 @@ footer h3 {
 /* ------------------------------------------
 # 98.0 - GUTTEMBERG BLOCKS - MINI
 --------------------------------------------- */
+.entry-content.row > * {
+        flex: 0 0 100%;
+        max-width: 100%;
+        width: 100%;
+}
+
 .wp-block-columns {
-	margin: 40px 0;
+        margin: 40px 0;
 }
 
 .wp-block-latest-posts li {

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -51,7 +51,7 @@
         <?php endif; ?>
     </div><!-- .entry-header -->
 
-    <div class="entry-content row">
+    <div class="<?php echo esc_attr( is_single() ? 'entry-content' : 'entry-content row' ); ?>">
 
         <?php
 	// funcion que muestra el contenido del post .. excerpt para index y todo para single(singular).


### PR DESCRIPTION
## Summary
- remove the Bootstrap `row` class from the single post content wrapper to avoid flex interference with Gutenberg blocks
- ensure layouts that still rely on `.entry-content.row` render direct children at full width via CSS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd370149348330a5870f285d572ff6