### PR TITLE
Add customizer control for logo max height

### DIFF
--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -60,6 +60,7 @@ function smile_web_get_dynamic_root_styles() {
                 $button_border                 = sanitize_hex_color( get_theme_mod( 'button_border', '#0F7B5C' ) );
                 $button_border_hover           = sanitize_hex_color( get_theme_mod( 'button_border_hover', '#0F7B5C' ) );
                 $button_border_radius          = absint( get_theme_mod( 'button_border_radius', 50 ) ) . 'px';
+                $logo_max_height               = absint( get_theme_mod( 'logo_max_height', 80 ) ) . 'px';
                 $whatsapp_button_offset_right  = absint( get_theme_mod( 'whatsapp_button_offset_right', 15 ) ) . 'px';
                 $whatsapp_button_offset_bottom = absint( get_theme_mod( 'whatsapp_button_offset_bottom', 15 ) ) . 'px';
 				$form_text                     = sanitize_hex_color( get_theme_mod( 'form_text', '#1A202C' ) );
@@ -145,6 +146,7 @@ function smile_web_get_dynamic_root_styles() {
                         --btn-border: ' . esc_attr( $button_border ) . ';
                         --btn-border-hover: ' . esc_attr( $button_border_hover ) . ';
                         --btn-radius: ' . esc_attr( $button_border_radius ) . ';
+                        --logo-max-height: ' . esc_attr( $logo_max_height ) . ';
                         --whatsapp-offset-right: ' . esc_attr( $whatsapp_button_offset_right ) . ';
                         --whatsapp-offset-bottom: ' . esc_attr( $whatsapp_button_offset_bottom ) . ';
                         --form-text: ' . esc_attr( $form_text ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -200,39 +200,74 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 		)
 	);
 
-		// Add Theme Appearance panel.
-		$wp_customize->add_panel(
-			'smile_theme_appearance',
-			array(
-				'title'      => esc_html__( 'Theme Appearance', 'smile-web' ),
-				'priority'   => 40,
-				'capability' => 'edit_theme_options',
-			)
-		);
+        // Add Theme Appearance panel.
+        $wp_customize->add_panel(
+                'smile_theme_appearance',
+                array(
+                        'title'      => esc_html__( 'Theme Appearance', 'smile-web' ),
+                        'priority'   => 40,
+                        'capability' => 'edit_theme_options',
+                )
+        );
 
-		// Add Buttons subsection.
-		$wp_customize->add_section(
-			'smile_theme_buttons',
-			array(
-				'title'      => esc_html__( 'Buttons', 'smile-web' ),
-				'priority'   => 10,
-				'capability' => 'edit_theme_options',
-				'panel'      => 'smile_theme_appearance',
-			)
-		);
+        // Add Header Logo subsection.
+        $wp_customize->add_section(
+                'smile_theme_header_logo',
+                array(
+                        'title'      => esc_html__( 'Header Logo', 'smile-web' ),
+                        'priority'   => 5,
+                        'capability' => 'edit_theme_options',
+                        'panel'      => 'smile_theme_appearance',
+                )
+        );
 
-		// Add Floating Elements subsection.
-		$wp_customize->add_section(
-			'smile_theme_floating_elements',
-			array(
-				'title'      => esc_html__( 'Floating Elements', 'smile-web' ),
-				'priority'   => 20,
-				'capability' => 'edit_theme_options',
-				'panel'      => 'smile_theme_appearance',
-			)
-		);
+        // Logo max height setting and control.
+        $wp_customize->add_setting(
+                'logo_max_height',
+                array(
+                        'default'           => 80,
+                        'sanitize_callback' => 'absint',
+                )
+        );
 
-		// Button radius setting and control.
+        $wp_customize->add_control(
+                'logo_max_height',
+                array(
+                        'label'       => esc_html__( 'Logo Maximum Height', 'smile-web' ),
+                        'description' => esc_html__( 'Control the maximum height of the header logo. Default: 80px.', 'smile-web' ),
+                        'section'     => 'smile_theme_header_logo',
+                        'type'        => 'number',
+                        'input_attrs' => array(
+                                'min'  => 0,
+                                'max'  => 400,
+                                'step' => 1,
+                        ),
+                )
+        );
+
+        // Add Buttons subsection.
+        $wp_customize->add_section(
+                'smile_theme_buttons',
+                array(
+                        'title'      => esc_html__( 'Buttons', 'smile-web' ),
+                        'priority'   => 10,
+                        'capability' => 'edit_theme_options',
+                        'panel'      => 'smile_theme_appearance',
+                )
+        );
+
+        // Add Floating Elements subsection.
+        $wp_customize->add_section(
+                'smile_theme_floating_elements',
+                array(
+                        'title'      => esc_html__( 'Floating Elements', 'smile-web' ),
+                        'priority'   => 20,
+                        'capability' => 'edit_theme_options',
+                        'panel'      => 'smile_theme_appearance',
+                )
+        );
+
+        // Button radius setting and control.
 		$wp_customize->add_setting(
 			'button_border_radius',
 			array(

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -387,8 +387,9 @@ a:visited:not([class*="btn"]):not([class*="button"]) {
 }
 
 #logo img {
-	max-height: 100%;
-	width: auto;
+        max-height: var(--logo-max-height, 80px);
+        height: auto;
+        width: auto;
 }
 
 #topBar {

--- a/style.css
+++ b/style.css
@@ -387,8 +387,9 @@ a:visited:not([class*="btn"]):not([class*="button"]) {
 }
 
 #logo img {
-	max-height: 100%;
-	width: auto;
+        max-height: var(--logo-max-height, 80px);
+        height: auto;
+        width: auto;
 }
 
 #topBar {


### PR DESCRIPTION
## Summary
- add a Header Logo section under Theme Appearance with a logo height setting and control
- export the logo max height as a CSS custom property from the dynamic styles
- update the LTR and RTL stylesheets to consume the new logo height variable

## Testing
- php -l inc/customizer-options.php
- php -l inc/customizer-dynamic-styles.php

------
https://chatgpt.com/codex/tasks/task_e_68cd650778b48330b6100e03bc674d33