### PR TITLE
Refactor inline styles into reusable classes

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -16,9 +16,9 @@ get_header();
 	<div class="container">
 		<div class="row">
 			<!-- Breadcrumbs -->
-			<div id="breadcrumbs" class="col-12">
-				<nav aria-label="breadcrumb">
-                                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
+                        <div id="breadcrumbs" class="col-12">
+                                <nav aria-label="breadcrumb" class="breadcrumb-nav">
+                                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb breadcrumb--primary">
 						<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 														<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>">
 								<span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -58,9 +58,50 @@ blockquote {
 }
 
 .btn:hover {
-	background-color: var(--btn-bg-hover);
-	color: var(--btn-text-hover);
-	border: 1px solid var(--btn-border-hover);
+        background-color: var(--btn-bg-hover);
+        color: var(--btn-text-hover);
+        border: 1px solid var(--btn-border-hover);
+}
+
+/*--------------------------------------------------------------
+# Admin - Color Management
+--------------------------------------------------------------*/
+.smile-v6-import-file {
+        margin-bottom: 10px;
+}
+
+.smile-v6-status {
+        margin-top: 10px;
+}
+
+.smile-v6-status-message {
+        display: inline-block;
+        font-weight: 600;
+}
+
+.smile-v6-status-message--info {
+        color: #0073aa;
+}
+
+.smile-v6-status-message--success {
+        color: #00a32a;
+}
+
+.smile-v6-status-message--error {
+        color: #d63384;
+}
+
+.button.smile-v6-reset-colors {
+        background-color: #dc3232;
+        border-color: #dc3232;
+        color: #fff;
+}
+
+.button.smile-v6-reset-colors:focus,
+.button.smile-v6-reset-colors:hover {
+        background-color: #b82828;
+        border-color: #b82828;
+        color: #fff;
 }
 
 /*--------------------------------------------------------------

--- a/assets/js/color-management.js
+++ b/assets/js/color-management.js
@@ -193,10 +193,10 @@
             const file = this.files[0];
             if (file && file.type === 'application/json') {
                 importButton.disabled = false;
-                statusDiv.innerHTML = '<span style="color: #0073aa;">File selected: ' + escapeHtml(file.name) + '</span>';
+                statusDiv.innerHTML = '<span class="smile-v6-status-message smile-v6-status-message--info">File selected: ' + escapeHtml(file.name) + '</span>';
             } else {
                 importButton.disabled = true;
-                statusDiv.innerHTML = '<span style="color: #d63384;">Please select a valid JSON file.</span>';
+                statusDiv.innerHTML = '<span class="smile-v6-status-message smile-v6-status-message--error">Please select a valid JSON file.</span>';
             }
         });
 
@@ -219,7 +219,7 @@
             // Disable button during import.
             importButton.disabled = true;
             importButton.textContent = 'Importing...';
-            statusDiv.innerHTML = '<span style="color: #0073aa;">Importing colors...</span>';
+            statusDiv.innerHTML = '<span class="smile-v6-status-message smile-v6-status-message--info">Importing colors...</span>';
 
             // Create form data.
             const formData = new FormData();
@@ -235,7 +235,7 @@
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    statusDiv.innerHTML = '<span style="color: #00a32a;">' + escapeHtml(data.data.message) + '</span>';
+                    statusDiv.innerHTML = '<span class="smile-v6-status-message smile-v6-status-message--success">' + escapeHtml(data.data.message) + '</span>';
                     showMessage(data.data.message, 'success');
 
                     // Refresh the customizer preview.
@@ -243,13 +243,13 @@
                         wp.customize.previewer.refresh();
                     }
                 } else {
-                    statusDiv.innerHTML = '<span style="color: #d63384;">' + escapeHtml(data.data.message) + '</span>';
+                    statusDiv.innerHTML = '<span class="smile-v6-status-message smile-v6-status-message--error">' + escapeHtml(data.data.message) + '</span>';
                     showMessage(data.data.message, 'error');
                 }
             })
             .catch(error => {
                 const errorMessage = 'Import failed. Please check the file format and try again.';
-                statusDiv.innerHTML = '<span style="color: #d63384;">' + errorMessage + '</span>';
+                statusDiv.innerHTML = '<span class="smile-v6-status-message smile-v6-status-message--error">' + errorMessage + '</span>';
                 showMessage(errorMessage, 'error');
             })
             .finally(() => {
@@ -291,7 +291,7 @@
             // Disable button during reset.
             resetButton.disabled = true;
             resetButton.textContent = 'Resetting...';
-            statusDiv.innerHTML = '<span style="color: #0073aa;">Resetting colors...</span>';
+            statusDiv.innerHTML = '<span class="smile-v6-status-message smile-v6-status-message--info">Resetting colors...</span>';
 
             // Create form data.
             const formData = new FormData();
@@ -306,7 +306,7 @@
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    statusDiv.innerHTML = '<span style="color: #00a32a;">' + escapeHtml(data.data.message) + '</span>';
+                    statusDiv.innerHTML = '<span class="smile-v6-status-message smile-v6-status-message--success">' + escapeHtml(data.data.message) + '</span>';
                     showMessage(data.data.message, 'success');
 
                     // Refresh the customizer preview.
@@ -314,13 +314,13 @@
                         wp.customize.previewer.refresh();
                     }
                 } else {
-                    statusDiv.innerHTML = '<span style="color: #d63384;">' + escapeHtml(data.data.message) + '</span>';
+                    statusDiv.innerHTML = '<span class="smile-v6-status-message smile-v6-status-message--error">' + escapeHtml(data.data.message) + '</span>';
                     showMessage(data.data.message, 'error');
                 }
             })
             .catch(error => {
                 const errorMessage = 'Reset failed. Please try again.';
-                statusDiv.innerHTML = '<span style="color: #d63384;">' + errorMessage + '</span>';
+                statusDiv.innerHTML = '<span class="smile-v6-status-message smile-v6-status-message--error">' + errorMessage + '</span>';
                 showMessage(errorMessage, 'error');
             })
             .finally(() => {

--- a/footer.php
+++ b/footer.php
@@ -114,7 +114,7 @@
 							if ( ! empty( $logo_footer ) ) {
 								?>
 																<a href="<?php echo esc_url( home_url( '' ) ); ?>">
-																		<img class="img-fluid" src="<?php echo esc_url( $logo_footer ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" width="300px" style="max-height:200px;">
+                                                                                                                               <img class="img-fluid footer-logo" src="<?php echo esc_url( $logo_footer ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" width="300px">
 																</a>
 														<?php } ?>
 						</figure>

--- a/front-page.php
+++ b/front-page.php
@@ -26,23 +26,10 @@ $intro_content_type       = get_theme_mod( 'intro_content_type', 'automatic' );
 $intro_custom_title       = get_theme_mod( 'intro_custom_title', '' );
 $intro_custom_description = get_theme_mod( 'intro_custom_description', '' );
 
-// ------------------------------------------------------------------
-// Header image.
-// ------------------------------------------------------------------
-$show_header_image = get_theme_mod( 'header_image_display', 'yes' );
-$header_image      = get_header_image();
-
-$intro_style = '';
-if ( 'yes' === $show_header_image && ! empty( $header_image ) ) {
-	$intro_style = sprintf(
-		'background-image: url(\'%s\'); background-size: cover; background-position: center; background-repeat: no-repeat;',
-		esc_url( $header_image )
-	);
-}
 ?>
 
 <!-- Intro -------------------------------------------------------- -->
-<div id="intro" style="<?php echo esc_attr( $intro_style ); ?>">
+<div id="intro" class="intro intro--front">
     <div class="container">
         <div class="row">
             <div class="col-md-6">

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -31,13 +31,19 @@ function smile_web_get_dynamic_root_styles() {
 				$accent_primary                = sanitize_hex_color( get_theme_mod( 'accent-primary', '#E8F2FF' ) );
 				$accent_secondary              = sanitize_hex_color( get_theme_mod( 'accent-secondary', '#2E5984' ) );
 				$accent_secondary_dark         = sanitize_hex_color( get_theme_mod( 'accent-secondary-dark', '#0B1426' ) );
-				$front_intro_overlay_color     = sanitize_hex_color( get_theme_mod( 'front_intro_overlay', '#0B1426' ) );
-				$front_intro_overlay_alpha     = floatval( get_theme_mod( 'front_intro_overlay_alpha', 0.8 ) );
-				$front_intro_overlay_alpha     = min( 1, max( 0, $front_intro_overlay_alpha ) );
-				list( $fio_r, $fio_g, $fio_b ) = sscanf( $front_intro_overlay_color, '#%02x%02x%02x' );
-				$front_intro_overlay           = sprintf( 'rgba(%d,%d,%d,%s)', $fio_r, $fio_g, $fio_b, $front_intro_overlay_alpha );
-				$front_intro_heading           = sanitize_hex_color( get_theme_mod( 'front_intro_heading', '#E8F2FF' ) );
-				$front_intro_text              = sanitize_hex_color( get_theme_mod( 'front_intro_text', '#FFFFFF' ) );
+                $front_intro_overlay_color     = sanitize_hex_color( get_theme_mod( 'front_intro_overlay', '#0B1426' ) );
+                $front_intro_overlay_alpha     = floatval( get_theme_mod( 'front_intro_overlay_alpha', 0.8 ) );
+                $front_intro_overlay_alpha     = min( 1, max( 0, $front_intro_overlay_alpha ) );
+                list( $fio_r, $fio_g, $fio_b ) = sscanf( $front_intro_overlay_color, '#%02x%02x%02x' );
+                $front_intro_overlay           = sprintf( 'rgba(%d,%d,%d,%s)', $fio_r, $fio_g, $fio_b, $front_intro_overlay_alpha );
+                $front_intro_heading           = sanitize_hex_color( get_theme_mod( 'front_intro_heading', '#E8F2FF' ) );
+                $front_intro_text              = sanitize_hex_color( get_theme_mod( 'front_intro_text', '#FFFFFF' ) );
+                $header_image_display          = get_theme_mod( 'header_image_display', 'yes' );
+                $header_image_url              = get_header_image();
+                $front_intro_image             = 'none';
+                if ( 'yes' === $header_image_display && ! empty( $header_image_url ) ) {
+                        $front_intro_image = 'url(' . esc_url_raw( $header_image_url ) . ')';
+                }
 				$page_intro_bg_color           = sanitize_hex_color( get_theme_mod( 'page_intro_bg', '#0B1426' ) );
 				$page_intro_bg_alpha           = floatval( get_theme_mod( 'page_intro_bg_alpha', 1 ) );
 				$page_intro_bg_alpha           = min( 1, max( 0, $page_intro_bg_alpha ) );
@@ -133,6 +139,7 @@ function smile_web_get_dynamic_root_styles() {
                         --bg-secondary: ' . esc_attr( $bg_secondary ) . ';
                         --breadcrumb-bg: ' . esc_attr( $breadcrumb_bg ) . ';
                         --front-intro-overlay: ' . esc_attr( $front_intro_overlay ) . ';
+                        --front-intro-image: ' . esc_attr( $front_intro_image ) . ';
                         --front-intro-heading: ' . esc_attr( $front_intro_heading ) . ';
                         --front-intro-text: ' . esc_attr( $front_intro_text ) . ';
                         --page-intro-bg: ' . esc_attr( $page_intro_bg ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -1484,11 +1484,11 @@ function smile_v6_register_custom_controls() {
     <span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
     <?php endif; ?>
 </label>
-<input type="file" class="smile-v6-import-file" accept=".json" style="margin-bottom: 10px;" />
+<input type="file" class="smile-v6-import-file" accept=".json" />
 <button type="button" class="button smile-v6-import-colors" disabled>
     <?php esc_html_e( 'Import Colors', 'smile-web' ); ?>
 </button>
-<div class="smile-v6-import-status" style="margin-top: 10px;"></div>
+<div class="smile-v6-import-status smile-v6-status"></div>
 <?php
 		}
 	}
@@ -1519,10 +1519,10 @@ function smile_v6_register_custom_controls() {
     <span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
     <?php endif; ?>
 </label>
-<button type="button" class="button smile-v6-reset-colors" style="background-color: #dc3232; color: white; border-color: #dc3232;">
+<button type="button" class="button smile-v6-reset-colors">
     <?php esc_html_e( 'Reset All Colors', 'smile-web' ); ?>
 </button>
-<div class="smile-v6-reset-status" style="margin-top: 10px;"></div>
+<div class="smile-v6-reset-status smile-v6-status"></div>
 <?php
 		}
 	}

--- a/index.php
+++ b/index.php
@@ -31,9 +31,9 @@ $page_slug  = ( false !== $page_for_posts_id ) ? get_post_field( 'post_name', $p
 <main id="main" class="blog-page area-padding bg-primary">
 	<div id="page">
 		<div class="container">
-			<div id="breadcrumbs">
-				<nav aria-label="<?php esc_attr_e( 'breadcrumb', 'smile-web' ); ?>">
-                                        <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
+                        <div id="breadcrumbs">
+                                <nav aria-label="<?php esc_attr_e( 'breadcrumb', 'smile-web' ); ?>" class="breadcrumb-nav">
+                                        <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb breadcrumb--primary">
 						<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 							<img class="mx-2"
 								src="<?php echo esc_url( get_template_directory_uri() . '/lib/fontawesome-free/svgs/solid/home.svg' ); ?>"

--- a/page-fullwidth.php
+++ b/page-fullwidth.php
@@ -18,10 +18,10 @@ get_header();
 
 <main id="main" class="blog-page area-padding bg-primary">
 <div class="cpy-2">
-	<div class="container">
-		<div id="breadcrumbs">
-			<nav aria-label="breadcrumb">
-                                <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
+        <div class="container">
+                <div id="breadcrumbs">
+                        <nav aria-label="breadcrumb" class="breadcrumb-nav">
+                                <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb breadcrumb--primary">
 										<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a><meta itemprop="position" content="1" />
 					</li>
 					<?php if ( $post->post_parent ) { ?>

--- a/page-sidebar.php
+++ b/page-sidebar.php
@@ -11,9 +11,9 @@ get_header();
 <main id="main" class="blog-page area-padding bg-secondary">
 	<div class="container">
 		<div class="row">
-			<div id="breadcrumbs">
-				<nav aria-label="breadcrumb">
-                                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
+                        <div id="breadcrumbs">
+                                <nav aria-label="breadcrumb" class="breadcrumb-nav">
+                                                                               <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb breadcrumb--primary">
 												<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 							<meta itemprop="position" content="1" />
 						</li>

--- a/page.php
+++ b/page.php
@@ -12,7 +12,7 @@
 
 get_header();
 ?>
-<div id="intro" class="pt-5" style="background-color: var(--page-intro-bg);">
+<div id="intro" class="intro intro--page pt-5">
 	<div class="container py-5 text-center">
 		<h1 class="title mt-2"><?php the_title(); ?></h1>
 		<a href="#main" class="btn-cta" rel="nofollow noopener" aria-label="<?php esc_attr_e( 'Go to main content', 'smile-web' ); ?>">
@@ -44,9 +44,9 @@ get_header();
 </div>
 <main id="main" class="bg-primary">
 	<div class="container py-2">
-		<div id="breadcrumbs">
-			<nav aria-label="breadcrumb" style="background-color: var(--breadcrumb-bg);">
-				<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb">
+                <div id="breadcrumbs">
+                        <nav aria-label="breadcrumb" class="breadcrumb-nav">
+                                <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb breadcrumb--primary">
 					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name"><?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 						<meta itemprop="position" content="1">
 					</li>

--- a/search.php
+++ b/search.php
@@ -19,9 +19,9 @@ get_header();
 <!-- #intro -->
 <main id="main" class="search-page pt-4 pb-4 bg-primary">
 	<div class="container">
-		<div id="breadcrumbs" class="pb-4">
-			<nav aria-label="breadcrumb">
-                             <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb" style="background-color: var(--breadcrumb-bg);">
+                <div id="breadcrumbs" class="pb-4">
+                        <nav aria-label="breadcrumb" class="breadcrumb-nav">
+                             <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb breadcrumb--primary">
                                         <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item"><i class="fa fa-home"></i><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="item" title="<?php echo esc_attr( get_bloginfo( 'title' ) ); ?>"><span itemprop="name">
 					<?php esc_html_e( 'Home', 'smile-web' ); ?></span></a>
 						<meta itemprop="position" content="1" />

--- a/single.php
+++ b/single.php
@@ -9,7 +9,7 @@
 
 get_header();
 ?>
-<div id="intro" class="pt-5" style="background-color: var(--single-intro-bg);">
+<div id="intro" class="intro intro--single pt-5">
 	<div class="container py-3">
 		<div class="row text-center py-2">
 			<h1 class="text-heading my-2"><?php the_title(); ?></h1>
@@ -92,9 +92,9 @@ get_header();
 </div><!-- #intro -->
 <main id="main" class="blog-page bg-primary">
 	<div class="container py-4">
-		<div id="breadcrumbs">
-			<nav aria-label="breadcrumb" style="background-color: var(--breadcrumb-bg);">
-				<ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb">
+                <div id="breadcrumbs">
+                        <nav aria-label="breadcrumb" class="breadcrumb-nav">
+                                <ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb breadcrumb--primary">
 					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 						<img class='mx-2' src="<?php echo esc_url( get_template_directory_uri() ); ?>/lib/fontawesome-free/svgs/solid/home.svg" alt="home" title="<?php esc_attr_e( 'Home', 'smile-web' ); ?>
 						" width="20px" height="20px">

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -865,11 +865,30 @@ main figure img,
 	height: auto;
 }
 
+.intro {
+    position: relative;
+}
+
+.intro--front {
+    background-image: var(--front-intro-image, none);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.intro--page {
+    background-color: var(--page-intro-bg, transparent);
+}
+
+.intro--single {
+    background-color: var(--single-intro-bg, transparent);
+}
+
 #intro::before {
     content: "";
     position: absolute;
     top: 0;
-    left: 0;
+    right: 0;
     width: 100%;
     height: 100%;
     /* aquí elegimos blanco semitransparente; cámbialo si quieres otro tono */
@@ -895,7 +914,20 @@ body.home #intro h1 {
 }
 
 body.home #intro p {
-	color: var(--front-intro-text);
+        color: var(--front-intro-text);
+}
+
+.breadcrumb--primary {
+    background-color: var(--breadcrumb-bg);
+}
+
+.search-card {
+    background-color: var(--color-white);
+}
+
+.footer-logo {
+    max-height: 200px;
+    height: auto;
 }
 
 /* Page Intro */
@@ -1304,10 +1336,6 @@ main ol li::marker {
 .alert-info {
 	background-color: var(--alert-info);
 	color: var(--color-white);
-}
-
-.d-none {
-	display: none !important;
 }
 
 
@@ -2009,11 +2037,11 @@ footer h3 {
         clip-path: none;
         display: inline-block;
         height: auto;
+        right: 1rem;
         margin: 0;
         overflow: visible;
         padding: 0.75rem 1.5rem;
         position: fixed;
-        right: 1rem;
         text-decoration: none;
         top: 1rem;
         width: auto;

--- a/style.css
+++ b/style.css
@@ -865,6 +865,25 @@ main figure img,
 	height: auto;
 }
 
+.intro {
+    position: relative;
+}
+
+.intro--front {
+    background-image: var(--front-intro-image, none);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.intro--page {
+    background-color: var(--page-intro-bg, transparent);
+}
+
+.intro--single {
+    background-color: var(--single-intro-bg, transparent);
+}
+
 #intro::before {
     content: "";
     position: absolute;
@@ -895,7 +914,20 @@ body.home #intro h1 {
 }
 
 body.home #intro p {
-	color: var(--front-intro-text);
+        color: var(--front-intro-text);
+}
+
+.breadcrumb--primary {
+    background-color: var(--breadcrumb-bg);
+}
+
+.search-card {
+    background-color: var(--color-white);
+}
+
+.footer-logo {
+    max-height: 200px;
+    height: auto;
 }
 
 /* Page Intro */

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -12,7 +12,7 @@
 
 ?>
 
-<article id="post-<?php the_ID(); ?>" class="row shadow mx-0 mb-4" style="background-color: var(--color-white);">
+<article id="post-<?php the_ID(); ?>" class="row shadow mx-0 mb-4 search-card">
 	<figure class="fit-figure p-0 m-0 col-md-4">
 		<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="nofollow">
 			<?php


### PR DESCRIPTION
## Summary
- replace inline styles across front-end templates with semantic classes for intros, breadcrumbs, search results, and the footer logo
- move styling into `style.css`/`style-rtl.css`, including a new `--front-intro-image` variable, and mirror updates for RTL output
- add admin stylesheet utilities and update Customizer controls plus the color management script to use class-based status messaging

## Testing
- npm run compile:rtl
- npm run lint:js *(fails: no files matching pattern "js/*.js")*
- npx wp-scripts lint-js 'assets/js/**/*.js' *(fails: prettier.resolveConfig.sync is not a function in project setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d267642a688330944580bc9276f78c