### PR TITLE
Remove breadcrumb background color customization

### DIFF
--- a/inc/color-management.php
+++ b/inc/color-management.php
@@ -35,7 +35,6 @@ function smile_v6_get_all_color_settings() {
 		// Background Colors.
 		'bg_primary'                => get_theme_mod( 'bg_primary', '#F7FAFC' ),
 		'bg_secondary'              => get_theme_mod( 'bg_secondary', '#E8F2FF' ),
-		'breadcrumb_bg_color'       => get_theme_mod( 'breadcrumb_bg_color', '#F7FAFC' ),
 
 		// Button Colors.
 		'button_text'               => get_theme_mod( 'button_text', '#FFFFFF' ),
@@ -139,7 +138,6 @@ function smile_v6_get_default_color_palette() {
 		// Background Colors.
 		'bg_primary'                => '#F7FAFC',
 		'bg_secondary'              => '#E8F2FF',
-		'breadcrumb_bg_color'       => '#F7FAFC',
 
 		// Button Colors.
 		'button_text'               => '#FFFFFF',

--- a/inc/customizer-dynamic-styles.php
+++ b/inc/customizer-dynamic-styles.php
@@ -57,8 +57,7 @@ function smile_web_get_dynamic_root_styles() {
 				$single_intro_bg               = sprintf( 'rgba(%d,%d,%d,%s)', $sib_r, $sib_g, $sib_b, $single_intro_bg_alpha );
 				$single_intro_heading          = sanitize_hex_color( get_theme_mod( 'single_intro_heading', '#E8F2FF' ) );
 				$bg_primary                    = sanitize_hex_color( get_theme_mod( 'bg_primary', '#F7FAFC' ) );
-				$bg_secondary                  = sanitize_hex_color( get_theme_mod( 'bg_secondary', '#E8F2FF' ) );
-				$breadcrumb_bg                 = sanitize_hex_color( get_theme_mod( 'breadcrumb_bg_color', '#F7FAFC' ) );
+                               $bg_secondary                  = sanitize_hex_color( get_theme_mod( 'bg_secondary', '#E8F2FF' ) );
 				$button_text                   = sanitize_hex_color( get_theme_mod( 'button_text', '#FFFFFF' ) );
 				$button_text_hover             = sanitize_hex_color( get_theme_mod( 'button_text_hover', '#0F7B5C' ) );
 				$button_bg                     = sanitize_hex_color( get_theme_mod( 'button_bg', '#0F7B5C' ) );
@@ -137,7 +136,6 @@ function smile_web_get_dynamic_root_styles() {
                         --color-white: ' . esc_attr( $color_white ) . ';
                         --bg-primary: ' . esc_attr( $bg_primary ) . ';
                         --bg-secondary: ' . esc_attr( $bg_secondary ) . ';
-                        --breadcrumb-bg: ' . esc_attr( $breadcrumb_bg ) . ';
                         --front-intro-overlay: ' . esc_attr( $front_intro_overlay ) . ';
                         --front-intro-image: ' . esc_attr( $front_intro_image ) . ';
                         --front-intro-heading: ' . esc_attr( $front_intro_heading ) . ';

--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -490,28 +490,24 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 		);
 
 		// Background color controls.
-				$background_colors = array(
-					'cta_bg'              => array(
-						'default' => '#ffc107',
-						'label'   => esc_html__( 'CTA Background Color', 'smile-web' ),
-					),
-					'bg_primary'          => array(
-						'default' => '#edf7ef',
-						'label'   => esc_html__( 'Primary Background Color', 'smile-web' ),
-					),
-					'bg_secondary'        => array(
-						'default' => '#f8f9fa',
-						'label'   => esc_html__( 'Secondary Background Color', 'smile-web' ),
-					),
-					'breadcrumb_bg_color' => array(
-						'default' => '#edf7ef',
-						'label'   => esc_html__( 'Breadcrumb Background Color', 'smile-web' ),
-					),
-					'footer_top_bg'       => array(
-						'default' => '#306a93',
-						'label'   => esc_html__( 'Top Footer Background Color', 'smile-web' ),
-					),
-					'selection_bg'        => array(
+                               $background_colors = array(
+                                        'cta_bg'              => array(
+                                                'default' => '#ffc107',
+                                                'label'   => esc_html__( 'CTA Background Color', 'smile-web' ),
+                                        ),
+                                        'bg_primary'          => array(
+                                                'default' => '#edf7ef',
+                                                'label'   => esc_html__( 'Primary Background Color', 'smile-web' ),
+                                        ),
+                                        'bg_secondary'        => array(
+                                                'default' => '#f8f9fa',
+                                                'label'   => esc_html__( 'Secondary Background Color', 'smile-web' ),
+                                        ),
+                                        'footer_top_bg'       => array(
+                                                'default' => '#306a93',
+                                                'label'   => esc_html__( 'Top Footer Background Color', 'smile-web' ),
+                                        ),
+                                        'selection_bg'        => array(
 						'default' => '#306a93',
 						'label'   => esc_html__( 'Selection Background Color', 'smile-web' ),
 					),

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -918,7 +918,7 @@ body.home #intro p {
 }
 
 .breadcrumb--primary {
-    background-color: var(--breadcrumb-bg);
+    background-color: transparent;
 }
 
 .search-card {

--- a/style.css
+++ b/style.css
@@ -918,7 +918,7 @@ body.home #intro p {
 }
 
 .breadcrumb--primary {
-    background-color: var(--breadcrumb-bg);
+    background-color: transparent;
 }
 
 .search-card {


### PR DESCRIPTION
## Summary
- remove the breadcrumb background color control from the customizer and color management helpers
- stop generating the breadcrumb background CSS variable and fall back to a transparent breadcrumb background in both LTR and RTL styles

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d27d54e6f88330be20881699f021c0