### PR TITLE
Add intro image meta support and editor panel

### DIFF
--- a/assets/js/editor-intro-image.js
+++ b/assets/js/editor-intro-image.js
@@ -1,0 +1,210 @@
+(function (window, wp) {
+        'use strict';
+
+        if (!wp || !wp.plugins || !wp.editPost || !wp.components || !wp.data || !wp.element || !wp.apiFetch) {
+                return;
+        }
+
+        var panelData = window.smileV6IntroImagePanel || {};
+        var metaKey = panelData.metaKey || 'smile_v6_intro_image_id';
+        var strings = panelData.strings || {};
+
+        var registerPlugin = wp.plugins.registerPlugin;
+        var PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;
+        var Button = wp.components.Button;
+        var Spinner = wp.components.Spinner;
+        var useSelect = wp.data.useSelect;
+        var useDispatch = wp.data.useDispatch;
+        var createElement = wp.element.createElement;
+        var useState = wp.element.useState;
+        var useEffect = wp.element.useEffect;
+        var MediaUpload = (wp.blockEditor && wp.blockEditor.MediaUpload) || (wp.editor && wp.editor.MediaUpload);
+        var MediaUploadCheck = (wp.blockEditor && wp.blockEditor.MediaUploadCheck) || (wp.editor && wp.editor.MediaUploadCheck);
+        var __ = wp.i18n.__;
+
+        if (!MediaUpload || !MediaUploadCheck) {
+                return;
+        }
+
+        var defaultStrings = {
+                panelTitle: __('Intro image', 'smile-web'),
+                panelDescription: __('Select an image to replace the intro highlight. It behaves like the custom header artwork.', 'smile-web'),
+                selectImageButton: __('Choose intro image', 'smile-web'),
+                replaceImageButton: __('Replace intro image', 'smile-web'),
+                clearImageButton: __('Remove intro image', 'smile-web'),
+                placeholderText: __('No intro image selected yet.', 'smile-web'),
+                previewLabel: __('Intro image preview', 'smile-web')
+        };
+
+        function getString(key) {
+                if (strings && strings[key]) {
+                        return strings[key];
+                }
+
+                return defaultStrings[key];
+        }
+
+        function IntroImagePanel() {
+                var postType = useSelect(function (select) {
+                        return select('core/editor').getCurrentPostType();
+                }, []);
+
+                var introImageId = useSelect(function (select) {
+                        var meta = select('core/editor').getEditedPostAttribute('meta') || {};
+                        var value = meta[metaKey];
+
+                        return value ? parseInt(value, 10) : 0;
+                }, []);
+
+                var editPost = useDispatch('core/editor').editPost;
+
+                var setMeta = function (value) {
+                        var newValue = {};
+                        newValue[metaKey] = value;
+                        editPost({ meta: newValue });
+                };
+
+                var mediaState = useState(null);
+                var mediaDetails = mediaState[0];
+                var setMediaDetails = mediaState[1];
+                var loadingState = useState(false);
+                var isLoading = loadingState[0];
+                var setIsLoading = loadingState[1];
+
+                useEffect(function () {
+                        var isSubscribed = true;
+
+                        if (!introImageId) {
+                                setMediaDetails(null);
+                                setIsLoading(false);
+
+                                return function () {
+                                        isSubscribed = false;
+                                };
+                        }
+
+                        setIsLoading(true);
+
+                        wp.apiFetch({ path: '/wp/v2/media/' + introImageId + '?context=edit' }).then(function (response) {
+                                if (!isSubscribed) {
+                                        return;
+                                }
+
+                                setMediaDetails(response || null);
+                                setIsLoading(false);
+                        }).catch(function () {
+                                if (!isSubscribed) {
+                                        return;
+                                }
+
+                                setMediaDetails(null);
+                                setIsLoading(false);
+                        });
+
+                        return function () {
+                                isSubscribed = false;
+                        };
+                }, [introImageId]);
+
+                if (['post', 'page'].indexOf(postType) === -1) {
+                        return null;
+                }
+
+                var previewUrl = '';
+                var previewAlt = '';
+
+                if (mediaDetails) {
+                        if (mediaDetails.media_details && mediaDetails.media_details.sizes) {
+                                if (mediaDetails.media_details.sizes.large && mediaDetails.media_details.sizes.large.source_url) {
+                                        previewUrl = mediaDetails.media_details.sizes.large.source_url;
+                                } else if (mediaDetails.media_details.sizes.medium_large && mediaDetails.media_details.sizes.medium_large.source_url) {
+                                        previewUrl = mediaDetails.media_details.sizes.medium_large.source_url;
+                                } else if (mediaDetails.media_details.sizes.full && mediaDetails.media_details.sizes.full.source_url) {
+                                        previewUrl = mediaDetails.media_details.sizes.full.source_url;
+                                }
+                        }
+
+                        if (!previewUrl && mediaDetails.source_url) {
+                                previewUrl = mediaDetails.source_url;
+                        }
+
+                        if (mediaDetails.alt_text) {
+                                previewAlt = mediaDetails.alt_text;
+                        }
+                }
+
+                return createElement(
+                        PluginDocumentSettingPanel,
+                        {
+                                name: 'smile-v6-intro-image-panel',
+                                title: getString('panelTitle'),
+                                className: 'smile-v6-intro-image-panel'
+                        },
+                        createElement(
+                                'p',
+                                { className: 'smile-v6-intro-image-panel__description' },
+                                getString('panelDescription')
+                        ),
+                        createElement(
+                                MediaUploadCheck,
+                                null,
+                                createElement(MediaUpload, {
+                                        onSelect: function (media) {
+                                                if (media && media.id) {
+                                                        setMeta(parseInt(media.id, 10));
+                                                }
+                                        },
+                                        value: introImageId,
+                                        allowedTypes: ['image'],
+                                        render: function (props) {
+                                                return createElement(
+                                                        Button,
+                                                        {
+                                                                onClick: props.open,
+                                                                className: 'smile-v6-intro-image-panel__select',
+                                                                icon: 'format-image',
+                                                                isPrimary: !introImageId,
+                                                                isSecondary: !!introImageId
+                                                        },
+                                                        introImageId ? getString('replaceImageButton') : getString('selectImageButton')
+                                                );
+                                        }
+                                })
+                        ),
+                        introImageId ? createElement(
+                                Button,
+                                {
+                                        onClick: function () {
+                                                setMeta(0);
+                                        },
+                                        className: 'smile-v6-intro-image-panel__clear',
+                                        isLink: true
+                                },
+                                getString('clearImageButton')
+                        ) : null,
+                        createElement(
+                                'div',
+                                {
+                                        className: 'smile-v6-intro-image-panel__preview',
+                                        role: 'group',
+                                        'aria-label': getString('previewLabel')
+                                },
+                                isLoading ? createElement(Spinner, null) : previewUrl ?
+                                        createElement(
+                                                'figure',
+                                                { className: 'smile-v6-intro-image-panel__figure' },
+                                                createElement('img', { src: previewUrl, alt: previewAlt })
+                                        ) :
+                                        createElement(
+                                                'p',
+                                                { className: 'smile-v6-intro-image-panel__placeholder' },
+                                                getString('placeholderText')
+                                        )
+                        )
+                );
+        }
+
+        registerPlugin('smile-v6-intro-image', {
+                render: IntroImagePanel
+        });
+}(window, window.wp));

--- a/functions.php
+++ b/functions.php
@@ -34,6 +34,12 @@ require get_template_directory() . '/inc/color-management.php';
 require get_template_directory() . '/inc/enqueues.php';
 
 /**
+ * Incluye los metadatos y assets del editor.
+ * Registra la configuración personalizada para el editor de bloques.
+ */
+require get_template_directory() . '/inc/editor-meta.php';
+
+/**
  * Incluye los estilos dinámicos del Customizer.
  * Genera reglas CSS dinámicas basadas en las opciones del tema definidas en el Customizer.
  */

--- a/inc/editor-meta.php
+++ b/inc/editor-meta.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Editor meta and assets bootstrap.
+ *
+ * @package smile-web
+ */
+
+/**
+ * Registers the intro image meta for supported post types.
+ *
+ * @since 6.0.8
+ *
+ * @return void
+ * @package smile-web
+ */
+function smile_v6_register_intro_image_meta() {
+        $args = array(
+                'type'              => 'integer',
+                'single'            => true,
+                'show_in_rest'      => true,
+                'sanitize_callback' => 'absint',
+                'default'           => 0,
+                'auth_callback'     => function() {
+                        return current_user_can( 'edit_posts' );
+                },
+        );
+
+        register_post_meta( array( 'post', 'page' ), 'smile_v6_intro_image_id', $args );
+}
+add_action( 'init', 'smile_v6_register_intro_image_meta' );
+
+/**
+ * Enqueues the block editor assets required for the intro image panel.
+ *
+ * @since 6.0.8
+ *
+ * @return void
+ * @package smile-web
+ */
+function smile_v6_enqueue_intro_image_editor_assets() {
+        $screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+        if ( $screen && ! in_array( $screen->post_type, array( 'post', 'page' ), true ) ) {
+                return;
+        }
+
+        $script_handle = 'smile-v6-editor-intro-image';
+        $script_path   = '/assets/js/editor-intro-image.js';
+
+        wp_enqueue_script(
+                $script_handle,
+                get_template_directory_uri() . $script_path,
+                array(
+                        'wp-plugins',
+                        'wp-edit-post',
+                        'wp-components',
+                        'wp-element',
+                        'wp-data',
+                        'wp-i18n',
+                        'wp-api-fetch',
+                        'wp-block-editor',
+                ),
+                filemtime( get_template_directory() . $script_path ),
+                true
+        );
+
+        wp_localize_script(
+                $script_handle,
+                'smileV6IntroImagePanel',
+                array(
+                        'metaKey' => 'smile_v6_intro_image_id',
+                        'strings' => array(
+                                'panelTitle'         => esc_html__( 'Intro image', 'smile-web' ),
+                                'panelDescription'   => esc_html__( 'Select an image to replace the intro highlight. It behaves like the custom header artwork.', 'smile-web' ),
+                                'selectImageButton'  => esc_html__( 'Choose intro image', 'smile-web' ),
+                                'replaceImageButton' => esc_html__( 'Replace intro image', 'smile-web' ),
+                                'clearImageButton'   => esc_html__( 'Remove intro image', 'smile-web' ),
+                                'placeholderText'    => esc_html__( 'No intro image selected yet.', 'smile-web' ),
+                                'previewLabel'       => esc_html__( 'Intro image preview', 'smile-web' ),
+                        ),
+                )
+        );
+
+        $panel_css = '.smile-v6-intro-image-panel__description{margin-top:0;}' .
+                '.smile-v6-intro-image-panel__select{margin-top:0.5rem;}' .
+                '.smile-v6-intro-image-panel__clear{margin-top:0.5rem;}' .
+                '.smile-v6-intro-image-panel__preview{margin-top:1rem;padding:0.75rem;border:1px dashed #dcdcde;border-radius:4px;background-color:#ffffff;text-align:center;}' .
+                '.smile-v6-intro-image-panel__figure{margin:0;}' .
+                '.smile-v6-intro-image-panel__figure img{display:block;max-width:100%;height:auto;margin:0 auto;}' .
+                '.smile-v6-intro-image-panel__placeholder{margin:0;color:#757575;}';
+
+        wp_add_inline_style( 'wp-edit-post', $panel_css );
+}
+add_action( 'enqueue_block_editor_assets', 'smile_v6_enqueue_intro_image_editor_assets' );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -151,6 +151,76 @@ if ( ! function_exists( 'smile_v6_post_thumbnail' ) ) :
 	}
 endif;
 
+if ( ! function_exists( 'smile_v6_get_intro_image_data' ) ) :
+        /**
+         * Retrieves the intro image data for a given post.
+         *
+         * @since 6.0.8
+         *
+         * @param int $post_id Post ID.
+         * @return array<string, mixed> Intro image data including url and metadata.
+         * @package smile-web
+         */
+        function smile_v6_get_intro_image_data( $post_id ) {
+                $post_id = absint( $post_id );
+
+                if ( 0 === $post_id ) {
+                        return array();
+                }
+
+                $meta_id = absint( get_post_meta( $post_id, 'smile_v6_intro_image_id', true ) );
+                $image_id = 0;
+
+                if ( $meta_id && wp_attachment_is_image( $meta_id ) ) {
+                        $image_id = $meta_id;
+                } elseif ( has_post_thumbnail( $post_id ) ) {
+                        $image_id = (int) get_post_thumbnail_id( $post_id );
+                }
+
+                if ( $image_id ) {
+                        $image_src = wp_get_attachment_image_src( $image_id, 'full' );
+
+                        if ( $image_src ) {
+                                $alt_meta   = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+                                $title_meta = get_post_meta( $image_id, '_wp_attachment_image_title', true );
+
+                                $alt_text   = trim( wp_strip_all_tags( (string) $alt_meta ) );
+                                $title_text = trim( wp_strip_all_tags( (string) $title_meta ) );
+
+                                if ( '' === $alt_text ) {
+                                        $alt_text = get_the_title( $post_id );
+                                }
+
+                                if ( '' === $title_text ) {
+                                        $title_text = get_the_title( $image_id );
+                                }
+
+                                return array(
+                                        'src'      => $image_src[0],
+                                        'width'    => isset( $image_src[1] ) ? (int) $image_src[1] : 0,
+                                        'height'   => isset( $image_src[2] ) ? (int) $image_src[2] : 0,
+                                        'alt'      => $alt_text,
+                                        'title'    => $title_text,
+                                        'class'    => 'attachment-' . $image_id,
+                                        'fallback' => false,
+                                );
+                        }
+                }
+
+                $site_name = get_bloginfo( 'name' );
+
+                return array(
+                        'src'      => get_template_directory_uri() . '/assets/img/thumbnail-header.jpg',
+                        'width'    => 1000,
+                        'height'   => 667,
+                        'alt'      => $site_name,
+                        'title'    => $site_name,
+                        'class'    => 'smile-v6-fallback-image',
+                        'fallback' => true,
+                );
+        }
+endif;
+
 if ( ! function_exists( 'wp_body_open' ) ) :
 	/**
 	 * Shim for sites older than 5.2.

--- a/page.php
+++ b/page.php
@@ -23,24 +23,27 @@ get_header();
 	// If minimum width is 768px.
 	if ( ! wp_is_mobile() ) :
 		?>
-	<figure id="intro-carousel" class="d-none d-md-block">
-		<?php
-			if ( has_post_thumbnail() ) :
-				$attachment_id = get_post_thumbnail_id( get_the_ID() );
-				$metadata      = wp_get_attachment_metadata( $attachment_id );
-				$height        = $metadata['height'];
-				$width         = $metadata['width'];
-				$alt           = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
-				$image_title   = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_title', true ) ) );
-				$src           = wp_get_attachment_url( $attachment_id );
-				$class         = 'attachment-' . $attachment_id;
-				?>
-		<img src="<?php echo esc_url( $src ); ?>" height="<?php echo esc_attr( $height ); ?>" width="<?php echo esc_attr( $width ); ?>" alt="<?php echo esc_attr( $alt ); ?>" title="<?php echo esc_attr( $image_title ); ?>" class="<?php echo esc_attr( $class ); ?>">
-		<?php else : ?>
-		<img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/img/thumbnail-header.jpg" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" width="1000" height="667">
-		<?php endif; ?>
-	</figure>
-	<?php endif; // END if minimum width is 768px. ?>
+        <figure id="intro-carousel" class="d-none d-md-block">
+                <?php
+                $intro_image = smile_v6_get_intro_image_data( get_the_ID() );
+
+                if ( ! empty( $intro_image ) && ! empty( $intro_image['src'] ) ) {
+                        $height_attr = ! empty( $intro_image['height'] ) ? sprintf( ' height="%s"', esc_attr( $intro_image['height'] ) ) : '';
+                        $width_attr  = ! empty( $intro_image['width'] ) ? sprintf( ' width="%s"', esc_attr( $intro_image['width'] ) ) : '';
+
+                        printf(
+                                '<img src="%1$s"%2$s%3$s alt="%4$s" title="%5$s" class="%6$s">',
+                                esc_url( $intro_image['src'] ),
+                                $height_attr,
+                                $width_attr,
+                                esc_attr( $intro_image['alt'] ),
+                                esc_attr( $intro_image['title'] ),
+                                esc_attr( $intro_image['class'] )
+                        );
+                }
+                ?>
+        </figure>
+        <?php endif; // END if minimum width is 768px. ?>
 </div>
 <main id="main" class="bg-primary">
 	<div class="container py-2">

--- a/single.php
+++ b/single.php
@@ -87,8 +87,30 @@ get_header();
 			// Mostrar el tiempo estimado de lectura.
 			echo '<p class="reading-time smile-web-single-date"><b>' . esc_html__( 'Reading time:', 'smile-web' ) . '</b> ' . esc_html( $reading_time ) . ' min</p>';
 			?>
-		</div>
-	</div>
+                </div>
+        </div>
+        <?php if ( ! wp_is_mobile() ) : ?>
+        <figure id="intro-carousel" class="d-none d-md-block">
+                <?php
+                $intro_image = smile_v6_get_intro_image_data( get_the_ID() );
+
+                if ( ! empty( $intro_image ) && ! empty( $intro_image['src'] ) ) {
+                        $height_attr = ! empty( $intro_image['height'] ) ? sprintf( ' height="%s"', esc_attr( $intro_image['height'] ) ) : '';
+                        $width_attr  = ! empty( $intro_image['width'] ) ? sprintf( ' width="%s"', esc_attr( $intro_image['width'] ) ) : '';
+
+                        printf(
+                                '<img src="%1$s"%2$s%3$s alt="%4$s" title="%5$s" class="%6$s">',
+                                esc_url( $intro_image['src'] ),
+                                $height_attr,
+                                $width_attr,
+                                esc_attr( $intro_image['alt'] ),
+                                esc_attr( $intro_image['title'] ),
+                                esc_attr( $intro_image['class'] )
+                        );
+                }
+                ?>
+        </figure>
+        <?php endif; ?>
 </div><!-- #intro -->
 <main id="main" class="blog-page bg-primary">
 	<div class="container py-4">

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2046,20 +2046,60 @@ footer h3 {
 
 .screen-reader-text:focus,
 .screen-reader-text:active {
-	clip: auto;
-	clip-path: none;
-	display: inline-block;
-	height: auto;
-	right: 1rem;
-	margin: 0;
-	overflow: visible;
-	padding: 0.75rem 1.5rem;
-	position: fixed;
-	text-decoration: none;
-	top: 1rem;
-	width: auto;
-	white-space: normal;
-	z-index: 1000;
+        clip: auto;
+        clip-path: none;
+        display: inline-block;
+        height: auto;
+        right: 1rem;
+        margin: 0;
+        overflow: visible;
+        padding: 0.75rem 1.5rem;
+        position: fixed;
+        text-decoration: none;
+        top: 1rem;
+        width: auto;
+        white-space: normal;
+        z-index: 1000;
+}
+
+/* ------------------------------------
+# Editor intro image panel
+--------------------------------------------- */
+.smile-v6-intro-image-panel__description {
+        margin-top: 0;
+}
+
+.smile-v6-intro-image-panel__select {
+        margin-top: 0.5rem;
+}
+
+.smile-v6-intro-image-panel__clear {
+        margin-top: 0.5rem;
+}
+
+.smile-v6-intro-image-panel__preview {
+        margin-top: 1rem;
+        padding: 0.75rem;
+        border: 1px dashed #dcdcde;
+        border-radius: 4px;
+        background-color: #ffffff;
+        text-align: center;
+}
+
+.smile-v6-intro-image-panel__figure {
+        margin: 0;
+}
+
+.smile-v6-intro-image-panel__figure img {
+        display: block;
+        max-width: 100%;
+        height: auto;
+        margin: 0 auto;
+}
+
+.smile-v6-intro-image-panel__placeholder {
+        margin: 0;
+        color: #757575;
 }
 
 .skip-link {

--- a/style.css
+++ b/style.css
@@ -2046,20 +2046,60 @@ footer h3 {
 
 .screen-reader-text:focus,
 .screen-reader-text:active {
-	clip: auto;
-	clip-path: none;
-	display: inline-block;
-	height: auto;
-	left: 1rem;
-	margin: 0;
-	overflow: visible;
-	padding: 0.75rem 1.5rem;
-	position: fixed;
-	text-decoration: none;
-	top: 1rem;
-	width: auto;
-	white-space: normal;
-	z-index: 1000;
+        clip: auto;
+        clip-path: none;
+        display: inline-block;
+        height: auto;
+        left: 1rem;
+        margin: 0;
+        overflow: visible;
+        padding: 0.75rem 1.5rem;
+        position: fixed;
+        text-decoration: none;
+        top: 1rem;
+        width: auto;
+        white-space: normal;
+        z-index: 1000;
+}
+
+/* ------------------------------------
+# Editor intro image panel
+--------------------------------------------- */
+.smile-v6-intro-image-panel__description {
+        margin-top: 0;
+}
+
+.smile-v6-intro-image-panel__select {
+        margin-top: 0.5rem;
+}
+
+.smile-v6-intro-image-panel__clear {
+        margin-top: 0.5rem;
+}
+
+.smile-v6-intro-image-panel__preview {
+        margin-top: 1rem;
+        padding: 0.75rem;
+        border: 1px dashed #dcdcde;
+        border-radius: 4px;
+        background-color: #ffffff;
+        text-align: center;
+}
+
+.smile-v6-intro-image-panel__figure {
+        margin: 0;
+}
+
+.smile-v6-intro-image-panel__figure img {
+        display: block;
+        max-width: 100%;
+        height: auto;
+        margin: 0 auto;
+}
+
+.smile-v6-intro-image-panel__placeholder {
+        margin: 0;
+        color: #757575;
 }
 
 .skip-link {


### PR DESCRIPTION
## Summary
- register the `smile_v6_intro_image_id` meta for posts and pages and load the associated block-editor assets
- add a sidebar plugin that lets editors pick or clear the intro image while previewing the selected media
- render the intro image meta (with fallbacks) in page and single templates and style the editor preview for LTR/RTL

## Testing
- npm run compile:rtl
- npm run lint:js *(fails: No files matching the pattern "js/*.js")*
- php -l inc/editor-meta.php

------
https://chatgpt.com/codex/tasks/task_e_68d28873309883309a01166da103921a