### PR TITLE
Register intro image meta per post type

### DIFF
--- a/inc/editor-meta.php
+++ b/inc/editor-meta.php
@@ -25,7 +25,9 @@ function smile_v6_register_intro_image_meta() {
                 },
         );
 
-        register_post_meta( array( 'post', 'page' ), 'smile_v6_intro_image_id', $args );
+	foreach ( array( 'post', 'page' ) as $post_type ) {
+		register_post_meta( $post_type, 'smile_v6_intro_image_id', $args );
+	}
 }
 add_action( 'init', 'smile_v6_register_intro_image_meta' );
 


### PR DESCRIPTION
## Summary
- register the intro image meta individually for each supported post type

## Testing
- php -l inc/editor-meta.php

------
https://chatgpt.com/codex/tasks/task_e_68d28e582b2c8330a645c9bf98752fd6