### PR TITLE
Adjust intro image helper options for pages

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -156,25 +156,46 @@ if ( ! function_exists( 'smile_v6_get_intro_image_data' ) ) :
          * Retrieves the intro image data for a given post.
          *
          * @since 6.0.8
+         * @since 6.0.9 Added the $args parameter to control fallbacks.
          *
-         * @param int $post_id Post ID.
+         * @param int   $post_id Post ID.
+         * @param array $args {
+         *     Optional. Arguments for controlling the image source selection.
+         *
+         *     @type bool $allow_featured Whether to allow the featured image to be used. Default true.
+         *     @type bool $allow_fallback Whether to allow the fallback image to be used. Default true.
+         * }
          * @return array<string, mixed> Intro image data including url and metadata.
          * @package smile-web
          */
-        function smile_v6_get_intro_image_data( $post_id ) {
+        function smile_v6_get_intro_image_data( $post_id, $args = array() ) {
                 $post_id = absint( $post_id );
 
                 if ( 0 === $post_id ) {
                         return array();
                 }
 
+                $args = wp_parse_args(
+                        (array) $args,
+                        array(
+                                'allow_featured' => true,
+                                'allow_fallback' => true,
+                        )
+                );
+
+                $allow_featured = wp_validate_boolean( $args['allow_featured'] );
+                $allow_fallback = wp_validate_boolean( $args['allow_fallback'] );
+
                 $meta_id = absint( get_post_meta( $post_id, 'smile_v6_intro_image_id', true ) );
                 $image_id = 0;
+                $source   = '';
 
                 if ( $meta_id && wp_attachment_is_image( $meta_id ) ) {
                         $image_id = $meta_id;
-                } elseif ( has_post_thumbnail( $post_id ) ) {
+                        $source   = 'meta';
+                } elseif ( $allow_featured && has_post_thumbnail( $post_id ) ) {
                         $image_id = (int) get_post_thumbnail_id( $post_id );
+                        $source   = 'featured';
                 }
 
                 if ( $image_id ) {
@@ -203,8 +224,13 @@ if ( ! function_exists( 'smile_v6_get_intro_image_data' ) ) :
                                         'title'    => $title_text,
                                         'class'    => 'attachment-' . $image_id,
                                         'fallback' => false,
+                                        'source'   => $source,
                                 );
                         }
+                }
+
+                if ( ! $allow_fallback ) {
+                        return array();
                 }
 
                 $site_name = get_bloginfo( 'name' );
@@ -217,6 +243,7 @@ if ( ! function_exists( 'smile_v6_get_intro_image_data' ) ) :
                         'title'    => $site_name,
                         'class'    => 'smile-v6-fallback-image',
                         'fallback' => true,
+                        'source'   => 'fallback',
                 );
         }
 endif;

--- a/page.php
+++ b/page.php
@@ -25,7 +25,13 @@ get_header();
 		?>
         <figure id="intro-carousel" class="d-none d-md-block">
                 <?php
-                $intro_image = smile_v6_get_intro_image_data( get_the_ID() );
+                $intro_image = smile_v6_get_intro_image_data(
+                        get_the_ID(),
+                        array(
+                                'allow_featured' => false,
+                                'allow_fallback' => false,
+                        )
+                );
 
                 if ( ! empty( $intro_image ) && ! empty( $intro_image['src'] ) ) {
                         $height_attr = ! empty( $intro_image['height'] ) ? sprintf( ' height="%s"', esc_attr( $intro_image['height'] ) ) : '';


### PR DESCRIPTION
## Summary
- allow `smile_v6_get_intro_image_data()` to accept options that govern featured and fallback usage
- track the selected source and honour the new flags when building intro image data
- ensure pages opt out of featured and fallback imagery when rendering the intro

## Testing
- php -l inc/template-tags.php
- php -l page.php

------
https://chatgpt.com/codex/tasks/task_e_68d2958a504c8330b2e89cb9ba2a193c