### PR TITLE
Restore intro carousel for single views on desktop

### DIFF
--- a/inc/enqueues.php
+++ b/inc/enqueues.php
@@ -376,6 +376,37 @@ CSS;
     margin: 0;
 }
 
+@media (min-width:768px) {
+    #intro-carousel {
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        z-index: -1;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background-color: var(--single-intro-bg);
+    }
+    #intro-carousel img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        position: absolute;
+        top: -50%;
+        left: -50%;
+        --0-transform: translate(50%, 50%);
+        --webkit-transform: translate(50%, 50%);
+        transform: translate(50%, 50%);
+        opacity: .3;
+    }
+    #intro .row {
+        display: flex;
+        justify-content: space-between;
+    }
+}
+
 CSS;
         }
 


### PR DESCRIPTION
## Summary
- add the desktop media query styles for the intro carousel on single views so featured images reappear
- keep the base display none rule untouched to preserve the mobile behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d29d72eb088330bf9ef293f0be3465