### PR TITLE
Update intro image handling on single posts

### DIFF
--- a/single.php
+++ b/single.php
@@ -92,7 +92,13 @@ get_header();
         <?php if ( ! wp_is_mobile() ) : ?>
         <figure id="intro-carousel" class="d-none d-md-block">
                 <?php
-                $intro_image = smile_v6_get_intro_image_data( get_the_ID() );
+                $intro_image = smile_v6_get_intro_image_data(
+                        get_the_ID(),
+                        array(
+                                'allow_featured' => true,
+                                'allow_fallback' => false,
+                        )
+                );
 
                 if ( ! empty( $intro_image ) && ! empty( $intro_image['src'] ) ) {
                         $height_attr = ! empty( $intro_image['height'] ) ? sprintf( ' height="%s"', esc_attr( $intro_image['height'] ) ) : '';


### PR DESCRIPTION
## Summary
- ensure single post intro image lookup allows featured images while disabling the fallback asset
- preserve existing rendering for posts with intro or featured images

## Testing
- php -l single.php

------
https://chatgpt.com/codex/tasks/task_e_68d2a16b54dc83309b604e9fe5dc29cd