### PR TITLE
Disable featured intro image fallback on single posts

### DIFF
--- a/single.php
+++ b/single.php
@@ -95,7 +95,7 @@ get_header();
                 $intro_image = smile_v6_get_intro_image_data(
                         get_the_ID(),
                         array(
-                                'allow_featured' => true,
+                                'allow_featured' => false,
                                 'allow_fallback' => false,
                         )
                 );


### PR DESCRIPTION
## Summary
- update the intro carousel image retrieval on single posts to require the custom intro image meta

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2a9c5d32c833085de3fdb459995da