### PR TITLE
Wrap intro header in initial loop and rewind posts

### DIFF
--- a/single.php
+++ b/single.php
@@ -8,11 +8,14 @@
  */
 
 get_header();
-?>
+
+while ( have_posts() ) :
+        the_post();
+        ?>
 <div id="intro" class="intro intro--single pt-5">
-	<div class="container py-3">
-		<div class="row text-center py-2">
-			<h1 class="text-heading my-2"><?php the_title(); ?></h1>
+        <div class="container py-3">
+                <div class="row text-center py-2">
+                        <h1 class="text-heading my-2"><?php the_title(); ?></h1>
 			<div class="entry-header d-flex justify-content-center">
 				<?php if ( is_single() ) : ?>
 				<span class="smile-web-single-date">
@@ -118,6 +121,11 @@ get_header();
         </figure>
         <?php endif; ?>
 </div><!-- #intro -->
+<?php
+endwhile;
+
+rewind_posts();
+?>
 <main id="main" class="blog-page bg-primary">
 	<div class="container py-4">
                 <div id="breadcrumbs">


### PR DESCRIPTION
## Summary
- wrap the intro header markup in an initial loop right after `get_header()` so it pulls data from the current post
- rewind the loop before rendering the main content to allow the template part section to run as before

## Testing
- php -l single.php

------
https://chatgpt.com/codex/tasks/task_e_68d2b5ec8f208330aa45913aaa6213ad