### PR TITLE
Adjust intro image panel to modern editor API

### DIFF
--- a/assets/js/editor-intro-image.js
+++ b/assets/js/editor-intro-image.js
@@ -1,7 +1,7 @@
 (function (window, wp) {
         'use strict';
 
-        if (!wp || !wp.plugins || !wp.editPost || !wp.components || !wp.data || !wp.element || !wp.apiFetch) {
+        if (!wp || !wp.plugins || (!wp.editor && !wp.editPost) || !wp.components || !wp.data || !wp.element || !wp.apiFetch) {
                 return;
         }
 
@@ -10,7 +10,12 @@
         var strings = panelData.strings || {};
 
         var registerPlugin = wp.plugins.registerPlugin;
-        var PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;
+        var PluginDocumentSettingPanel = (wp.editor && wp.editor.PluginDocumentSettingPanel) ||
+                (wp.editPost && wp.editPost.PluginDocumentSettingPanel);
+
+        if (!PluginDocumentSettingPanel) {
+                return;
+        }
         var Button = wp.components.Button;
         var Spinner = wp.components.Spinner;
         var useSelect = wp.data.useSelect;

--- a/inc/editor-meta.php
+++ b/inc/editor-meta.php
@@ -54,6 +54,7 @@ function smile_v6_enqueue_intro_image_editor_assets() {
                 get_template_directory_uri() . $script_path,
                 array(
                         'wp-plugins',
+                        'wp-editor',
                         'wp-edit-post',
                         'wp-components',
                         'wp-element',


### PR DESCRIPTION
## Summary
- update the intro image editor plugin to prefer `wp.editor.PluginDocumentSettingPanel` with a graceful fallback
- add the `wp-editor` dependency when enqueueing the sidebar script so the new component is available

## Testing
- `npm run lint:js` *(fails: No files matching the pattern "js/*.js" were found.)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf4c3d52c8330b924e4f98840e218