### PR TITLE
Fix intro image panel to use wp.editor API

### DIFF
--- a/assets/js/editor-intro-image.js
+++ b/assets/js/editor-intro-image.js
@@ -1,7 +1,7 @@
 (function (window, wp) {
         'use strict';
 
-        if (!wp || !wp.plugins || (!wp.editor && !wp.editPost) || !wp.components || !wp.data || !wp.element || !wp.apiFetch) {
+        if (!wp || !wp.plugins || !wp.components || !wp.data || !wp.element || !wp.apiFetch || !wp.i18n) {
                 return;
         }
 
@@ -10,12 +10,6 @@
         var strings = panelData.strings || {};
 
         var registerPlugin = wp.plugins.registerPlugin;
-        var PluginDocumentSettingPanel = (wp.editor && wp.editor.PluginDocumentSettingPanel) ||
-                (wp.editPost && wp.editPost.PluginDocumentSettingPanel);
-
-        if (!PluginDocumentSettingPanel) {
-                return;
-        }
         var Button = wp.components.Button;
         var Spinner = wp.components.Spinner;
         var useSelect = wp.data.useSelect;
@@ -27,7 +21,7 @@
         var MediaUploadCheck = (wp.blockEditor && wp.blockEditor.MediaUploadCheck) || (wp.editor && wp.editor.MediaUploadCheck);
         var __ = wp.i18n.__;
 
-        if (!MediaUpload || !MediaUploadCheck) {
+        if (!registerPlugin || !MediaUpload || !MediaUploadCheck) {
                 return;
         }
 
@@ -49,167 +43,207 @@
                 return defaultStrings[key];
         }
 
-        function IntroImagePanel() {
-                var postType = useSelect(function (select) {
-                        return select('core/editor').getCurrentPostType();
-                }, []);
+        var hasRegistered = false;
+        var MAX_ATTEMPTS = 10;
+        var RETRY_DELAY = 50;
 
-                var introImageId = useSelect(function (select) {
-                        var meta = select('core/editor').getEditedPostAttribute('meta') || {};
-                        var value = meta[metaKey];
+        function registerIntroImagePanel(PluginDocumentSettingPanel) {
+                if (hasRegistered || !PluginDocumentSettingPanel) {
+                        return;
+                }
 
-                        return value ? parseInt(value, 10) : 0;
-                }, []);
+                hasRegistered = true;
 
-                var editPost = useDispatch('core/editor').editPost;
+                function IntroImagePanel() {
+                        var postType = useSelect(function (select) {
+                                return select('core/editor').getCurrentPostType();
+                        }, []);
 
-                var setMeta = function (value) {
-                        var newValue = {};
-                        newValue[metaKey] = value;
-                        editPost({ meta: newValue });
-                };
+                        var introImageId = useSelect(function (select) {
+                                var meta = select('core/editor').getEditedPostAttribute('meta') || {};
+                                var value = meta[metaKey];
 
-                var mediaState = useState(null);
-                var mediaDetails = mediaState[0];
-                var setMediaDetails = mediaState[1];
-                var loadingState = useState(false);
-                var isLoading = loadingState[0];
-                var setIsLoading = loadingState[1];
+                                return value ? parseInt(value, 10) : 0;
+                        }, []);
 
-                useEffect(function () {
-                        var isSubscribed = true;
+                        var editPost = useDispatch('core/editor').editPost;
 
-                        if (!introImageId) {
-                                setMediaDetails(null);
-                                setIsLoading(false);
+                        var setMeta = function (value) {
+                                var newValue = {};
+                                newValue[metaKey] = value;
+                                editPost({ meta: newValue });
+                        };
+
+                        var mediaState = useState(null);
+                        var mediaDetails = mediaState[0];
+                        var setMediaDetails = mediaState[1];
+                        var loadingState = useState(false);
+                        var isLoading = loadingState[0];
+                        var setIsLoading = loadingState[1];
+
+                        useEffect(function () {
+                                var isSubscribed = true;
+
+                                if (!introImageId) {
+                                        setMediaDetails(null);
+                                        setIsLoading(false);
+
+                                        return function () {
+                                                isSubscribed = false;
+                                        };
+                                }
+
+                                setIsLoading(true);
+
+                                wp.apiFetch({ path: '/wp/v2/media/' + introImageId + '?context=edit' }).then(function (response) {
+                                        if (!isSubscribed) {
+                                                return;
+                                        }
+
+                                        setMediaDetails(response || null);
+                                        setIsLoading(false);
+                                }).catch(function () {
+                                        if (!isSubscribed) {
+                                                return;
+                                        }
+
+                                        setMediaDetails(null);
+                                        setIsLoading(false);
+                                });
 
                                 return function () {
                                         isSubscribed = false;
                                 };
+                        }, [introImageId]);
+
+                        if (['post', 'page'].indexOf(postType) === -1) {
+                                return null;
                         }
 
-                        setIsLoading(true);
+                        var previewUrl = '';
+                        var previewAlt = '';
 
-                        wp.apiFetch({ path: '/wp/v2/media/' + introImageId + '?context=edit' }).then(function (response) {
-                                if (!isSubscribed) {
-                                        return;
-                                }
-
-                                setMediaDetails(response || null);
-                                setIsLoading(false);
-                        }).catch(function () {
-                                if (!isSubscribed) {
-                                        return;
-                                }
-
-                                setMediaDetails(null);
-                                setIsLoading(false);
-                        });
-
-                        return function () {
-                                isSubscribed = false;
-                        };
-                }, [introImageId]);
-
-                if (['post', 'page'].indexOf(postType) === -1) {
-                        return null;
-                }
-
-                var previewUrl = '';
-                var previewAlt = '';
-
-                if (mediaDetails) {
-                        if (mediaDetails.media_details && mediaDetails.media_details.sizes) {
-                                if (mediaDetails.media_details.sizes.large && mediaDetails.media_details.sizes.large.source_url) {
-                                        previewUrl = mediaDetails.media_details.sizes.large.source_url;
-                                } else if (mediaDetails.media_details.sizes.medium_large && mediaDetails.media_details.sizes.medium_large.source_url) {
-                                        previewUrl = mediaDetails.media_details.sizes.medium_large.source_url;
-                                } else if (mediaDetails.media_details.sizes.full && mediaDetails.media_details.sizes.full.source_url) {
-                                        previewUrl = mediaDetails.media_details.sizes.full.source_url;
-                                }
-                        }
-
-                        if (!previewUrl && mediaDetails.source_url) {
-                                previewUrl = mediaDetails.source_url;
-                        }
-
-                        if (mediaDetails.alt_text) {
-                                previewAlt = mediaDetails.alt_text;
-                        }
-                }
-
-                return createElement(
-                        PluginDocumentSettingPanel,
-                        {
-                                name: 'smile-v6-intro-image-panel',
-                                title: getString('panelTitle'),
-                                className: 'smile-v6-intro-image-panel'
-                        },
-                        createElement(
-                                'p',
-                                { className: 'smile-v6-intro-image-panel__description' },
-                                getString('panelDescription')
-                        ),
-                        createElement(
-                                MediaUploadCheck,
-                                null,
-                                createElement(MediaUpload, {
-                                        onSelect: function (media) {
-                                                if (media && media.id) {
-                                                        setMeta(parseInt(media.id, 10));
-                                                }
-                                        },
-                                        value: introImageId,
-                                        allowedTypes: ['image'],
-                                        render: function (props) {
-                                                return createElement(
-                                                        Button,
-                                                        {
-                                                                onClick: props.open,
-                                                                className: 'smile-v6-intro-image-panel__select',
-                                                                icon: 'format-image',
-                                                                isPrimary: !introImageId,
-                                                                isSecondary: !!introImageId
-                                                        },
-                                                        introImageId ? getString('replaceImageButton') : getString('selectImageButton')
-                                                );
+                        if (mediaDetails) {
+                                if (mediaDetails.media_details && mediaDetails.media_details.sizes) {
+                                        if (mediaDetails.media_details.sizes.large && mediaDetails.media_details.sizes.large.source_url) {
+                                                previewUrl = mediaDetails.media_details.sizes.large.source_url;
+                                        } else if (mediaDetails.media_details.sizes.medium_large && mediaDetails.media_details.sizes.medium_large.source_url) {
+                                                previewUrl = mediaDetails.media_details.sizes.medium_large.source_url;
+                                        } else if (mediaDetails.media_details.sizes.full && mediaDetails.media_details.sizes.full.source_url) {
+                                                previewUrl = mediaDetails.media_details.sizes.full.source_url;
                                         }
-                                })
-                        ),
-                        introImageId ? createElement(
-                                Button,
+                                }
+
+                                if (!previewUrl && mediaDetails.source_url) {
+                                        previewUrl = mediaDetails.source_url;
+                                }
+
+                                if (mediaDetails.alt_text) {
+                                        previewAlt = mediaDetails.alt_text;
+                                }
+                        }
+
+                        return createElement(
+                                PluginDocumentSettingPanel,
                                 {
-                                        onClick: function () {
-                                                setMeta(0);
+                                        name: 'smile-v6-intro-image-panel',
+                                        title: getString('panelTitle'),
+                                        className: 'smile-v6-intro-image-panel'
+                                },
+                                createElement(
+                                        'p',
+                                        { className: 'smile-v6-intro-image-panel__description' },
+                                        getString('panelDescription')
+                                ),
+                                createElement(
+                                        MediaUploadCheck,
+                                        null,
+                                        createElement(MediaUpload, {
+                                                onSelect: function (media) {
+                                                        if (media && media.id) {
+                                                                setMeta(parseInt(media.id, 10));
+                                                        }
+                                                },
+                                                value: introImageId,
+                                                allowedTypes: ['image'],
+                                                render: function (props) {
+                                                        return createElement(
+                                                                Button,
+                                                                {
+                                                                        onClick: props.open,
+                                                                        className: 'smile-v6-intro-image-panel__select',
+                                                                        icon: 'format-image',
+                                                                        isPrimary: !introImageId,
+                                                                        isSecondary: !!introImageId
+                                                                },
+                                                                introImageId ? getString('replaceImageButton') : getString('selectImageButton')
+                                                        );
+                                                }
+                                        })
+                                ),
+                                introImageId ? createElement(
+                                        Button,
+                                        {
+                                                onClick: function () {
+                                                        setMeta(0);
+                                                },
+                                                className: 'smile-v6-intro-image-panel__clear',
+                                                isLink: true
                                         },
-                                        className: 'smile-v6-intro-image-panel__clear',
-                                        isLink: true
-                                },
-                                getString('clearImageButton')
-                        ) : null,
-                        createElement(
-                                'div',
-                                {
-                                        className: 'smile-v6-intro-image-panel__preview',
-                                        role: 'group',
-                                        'aria-label': getString('previewLabel')
-                                },
-                                isLoading ? createElement(Spinner, null) : previewUrl ?
-                                        createElement(
-                                                'figure',
-                                                { className: 'smile-v6-intro-image-panel__figure' },
-                                                createElement('img', { src: previewUrl, alt: previewAlt })
-                                        ) :
-                                        createElement(
-                                                'p',
-                                                { className: 'smile-v6-intro-image-panel__placeholder' },
-                                                getString('placeholderText')
-                                        )
-                        )
-                );
+                                        getString('clearImageButton')
+                                ) : null,
+                                createElement(
+                                        'div',
+                                        {
+                                                className: 'smile-v6-intro-image-panel__preview',
+                                                role: 'group',
+                                                'aria-label': getString('previewLabel')
+                                        },
+                                        isLoading ? createElement(Spinner, null) : previewUrl ?
+                                                createElement(
+                                                        'figure',
+                                                        { className: 'smile-v6-intro-image-panel__figure' },
+                                                        createElement('img', { src: previewUrl, alt: previewAlt })
+                                                ) :
+                                                createElement(
+                                                        'p',
+                                                        { className: 'smile-v6-intro-image-panel__placeholder' },
+                                                        getString('placeholderText')
+                                                )
+                                )
+                        );
+                }
+
+                registerPlugin('smile-v6-intro-image', {
+                        render: IntroImagePanel
+                });
         }
 
-        registerPlugin('smile-v6-intro-image', {
-                render: IntroImagePanel
-        });
+        function attemptRegistration(remainingAttempts) {
+                if (hasRegistered) {
+                        return;
+                }
+
+                var pluginPanel = wp.editor && wp.editor.PluginDocumentSettingPanel;
+
+                if (!pluginPanel && remainingAttempts > 0) {
+                        window.setTimeout(function () {
+                                attemptRegistration(remainingAttempts - 1);
+                        }, RETRY_DELAY);
+
+                        return;
+                }
+
+                if (!pluginPanel && wp.editPost && wp.editPost.PluginDocumentSettingPanel) {
+                        pluginPanel = wp.editPost.PluginDocumentSettingPanel;
+                }
+
+                if (!pluginPanel) {
+                        return;
+                }
+
+                registerIntroImagePanel(pluginPanel);
+        }
+
+        attemptRegistration(MAX_ATTEMPTS);
 }(window, window.wp));


### PR DESCRIPTION
## Summary
- guard the intro image editor script against missing WordPress globals, including wp.i18n and registerPlugin
- register the intro image document settings panel through wp.editor with retry logic before falling back to wp.editPost to avoid Gutenberg deprecation warnings

## Testing
- npm run lint:js *(fails: No files matching the pattern "js/*.js" were found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ab4ee90883308cc3e2cfda50ad41