### PR TITLE
Enable revisions for intro image meta

### DIFF
--- a/inc/editor-meta.php
+++ b/inc/editor-meta.php
@@ -23,6 +23,7 @@ function smile_v6_register_intro_image_meta() {
                 'auth_callback'     => function() {
                         return current_user_can( 'edit_posts' );
                 },
+                'revisions_enabled' => true,
         );
 
 	foreach ( array( 'post', 'page' ) as $post_type ) {


### PR DESCRIPTION
## Summary
- allow the intro image meta field to participate in revisions/autosaves so its value is preserved on subsequent saves

## Testing
- php -l inc/editor-meta.php

------
https://chatgpt.com/codex/tasks/task_e_68d3bce90f9083309bf70fac47279b87