### PR TITLE
Only render intro carousel image when featured image exists

### DIFF
--- a/page.php
+++ b/page.php
@@ -20,27 +20,23 @@ get_header();
 		</a>
 	</div>
 	<?php
-	// If minimum width is 768px.
-	if ( ! wp_is_mobile() ) :
+	// If minimum width is 768px and the page has a featured image.
+	if ( ! wp_is_mobile() && has_post_thumbnail() ) :
+		$attachment_id = get_post_thumbnail_id( get_the_ID() );
+		$metadata      = wp_get_attachment_metadata( $attachment_id );
+		$height        = isset( $metadata['height'] ) ? (int) $metadata['height'] : '';
+		$width         = isset( $metadata['width'] ) ? (int) $metadata['width'] : '';
+		$alt           = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
+		$image_title   = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_title', true ) ) );
+		$src           = wp_get_attachment_url( $attachment_id );
+		$class         = 'attachment-' . $attachment_id;
+		$height_attr   = '' !== $height ? ' height="' . esc_attr( $height ) . '"' : '';
+		$width_attr    = '' !== $width ? ' width="' . esc_attr( $width ) . '"' : '';
 		?>
 	<figure id="intro-carousel" class="d-none d-md-block">
-		<?php
-			if ( has_post_thumbnail() ) :
-				$attachment_id = get_post_thumbnail_id( get_the_ID() );
-				$metadata      = wp_get_attachment_metadata( $attachment_id );
-				$height        = $metadata['height'];
-				$width         = $metadata['width'];
-				$alt           = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
-				$image_title   = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_title', true ) ) );
-				$src           = wp_get_attachment_url( $attachment_id );
-				$class         = 'attachment-' . $attachment_id;
-				?>
-		<img src="<?php echo esc_url( $src ); ?>" height="<?php echo esc_attr( $height ); ?>" width="<?php echo esc_attr( $width ); ?>" alt="<?php echo esc_attr( $alt ); ?>" title="<?php echo esc_attr( $image_title ); ?>" class="<?php echo esc_attr( $class ); ?>">
-		<?php else : ?>
-		<img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/img/thumbnail-header.jpg" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" width="1000" height="667">
-		<?php endif; ?>
+		<img src="<?php echo esc_url( $src ); ?>"<?php echo $height_attr; ?><?php echo $width_attr; ?> alt="<?php echo esc_attr( $alt ); ?>" title="<?php echo esc_attr( $image_title ); ?>" class="<?php echo esc_attr( $class ); ?>">
 	</figure>
-	<?php endif; // END if minimum width is 768px. ?>
+	<?php endif; // END if minimum width is 768px and featured image exists. ?>
 </div>
 <main id="main" class="bg-primary">
 	<div class="container py-2">


### PR DESCRIPTION
## Summary
- avoid displaying the default intro carousel image when a page has no featured image
- keep image markup limited to desktop view when a featured image is available, reusing attachment metadata for attributes

## Testing
- php -l page.php

------
https://chatgpt.com/codex/tasks/task_e_68d3ce8ee5348330a0ce5424ea6bb81a