### PR TITLE
Limit category display to a single term

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -101,10 +101,16 @@ $intro_custom_description = get_theme_mod( 'intro_custom_description', '' );
 					?>
 				<article <?php post_class( 'blog-col col-md-4 mb-4 mx-0' ); ?>>
 					<?php
-										$categories_list = get_the_category_list( '</li><li>' );
-					if ( $categories_list ) {
-							echo '<div class="category"><ul class="post-categories"><li>' . wp_kses_post( $categories_list ) . '</li></ul></div>';
-					}
+                                        $display_category = smile_v6_get_display_category();
+                                        if ( $display_category ) {
+                                                echo '<div class="category"><ul class="post-categories">';
+                                                printf(
+                                                        '<li><a href="%1$s">%2$s</a></li>',
+                                                        esc_url( get_category_link( $display_category->term_id ) ),
+                                                        esc_html( $display_category->name )
+                                                );
+                                                echo '</ul></div>';
+                                        }
 					?>
 
 					<figure class="shadow">

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -57,12 +57,16 @@ if ( ! function_exists( 'smile_v6_entry_footer' ) ) :
 	function smile_v6_entry_footer() {
 		// Hide category and tag text for pages.
 		if ( 'post' === get_post_type() ) {
-			/* translators: used between list items, there is a space after the comma */
-			$categories_list = get_the_category_list( esc_html__( ', ', 'smile-web' ) );
-			if ( $categories_list ) {
-				/* translators: 1: list of categories. */
-				printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'smile-web' ) . '</span>', $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			}
+                        $display_category = smile_v6_get_display_category();
+                        if ( $display_category ) {
+                                $category_output = sprintf(
+                                        '<a href="%1$s">%2$s</a>',
+                                        esc_url( get_category_link( $display_category->term_id ) ),
+                                        esc_html( $display_category->name )
+                                );
+                                /* translators: 1: category name. */
+                                printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'smile-web' ) . '</span>', $category_output ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                        }
 
 			/* translators: used between list items, there is a space after the comma */
 			$tags_list = get_the_tag_list( '', esc_html_x( ', ', 'list item separator', 'smile-web' ) );
@@ -152,14 +156,54 @@ if ( ! function_exists( 'smile_v6_post_thumbnail' ) ) :
 endif;
 
 if ( ! function_exists( 'wp_body_open' ) ) :
-	/**
-	 * Shim for sites older than 5.2.
-	 *
-	 * @link https://core.trac.wordpress.org/ticket/12563
-	 */
-	function wp_body_open() {
-		do_action( 'wp_body_open' );
-	}
+        /**
+         * Shim for sites older than 5.2.
+         *
+         * @link https://core.trac.wordpress.org/ticket/12563
+         */
+        function wp_body_open() {
+                do_action( 'wp_body_open' );
+        }
+endif;
+
+
+if ( ! function_exists( 'smile_v6_get_display_category' ) ) :
+        /**
+         * Retrieves the category that should be displayed for a post.
+         *
+         * Prefers a category different from "Uncategorized" when available.
+         *
+         * @since 6.0.8
+         * @package smile-web
+         *
+         * @param int $post_id Optional. Post ID. Defaults to the current post.
+         * @return WP_Term|null Category term object or null when not available.
+         */
+        function smile_v6_get_display_category( $post_id = 0 ) {
+                $post_id = (int) $post_id;
+
+                if ( 0 === $post_id ) {
+                        $post_id = get_the_ID();
+                }
+
+                if ( empty( $post_id ) ) {
+                        return null;
+                }
+
+                $categories = get_the_category( $post_id );
+
+                if ( empty( $categories ) || is_wp_error( $categories ) ) {
+                        return null;
+                }
+
+                foreach ( $categories as $category ) {
+                        if ( 'uncategorized' !== $category->slug ) {
+                                return $category;
+                        }
+                }
+
+                return $categories[0];
+        }
 endif;
 
 

--- a/index.php
+++ b/index.php
@@ -111,15 +111,13 @@ $page_slug  = ( false !== $page_for_posts_id ) ? get_post_field( 'post_name', $p
                                                                         <article class="blog-col col-md-6 mb-4 mx-0">
                                                                                 <div class="category">
                                                                                         <?php
-                                                                                        $categories = get_the_category();
-                                                                                        if ( $categories ) {
-                                                                                                foreach ( $categories as $category ) {
-                                                                                                        printf(
-                                                                                                                '<a href="%1$s">%2$s</a>',
-                                                                                                                esc_url( get_category_link( $category->term_id ) ),
-                                                                                                                esc_html( $category->name )
-                                                                                                        );
-                                                                                                }
+                                                                                        $display_category = smile_v6_get_display_category();
+                                                                                        if ( $display_category ) {
+                                                                                                printf(
+                                                                                                        '<a href="%1$s">%2$s</a>',
+                                                                                                        esc_url( get_category_link( $display_category->term_id ) ),
+                                                                                                        esc_html( $display_category->name )
+                                                                                                );
                                                                                         }
                                                                                         ?>
                                                                                 </div>

--- a/page-sidebar.php
+++ b/page-sidebar.php
@@ -100,13 +100,13 @@ get_header();
 		$title_cat_id = get_cat_ID( get_the_title() );
 				// translators: %s: Title of the current post.
 				$text_related = sprintf( esc_html__( 'Articles related with title: %s', 'smile-web' ), get_the_title() );
-	} else {
-		$categories = get_the_category();
-		if ( ! empty( $categories ) ) {
-			$first_cat_id = $categories[0]->term_id;
-		} else {
-			$default_cat = 0;
-		}
+        } else {
+                $display_category = smile_v6_get_display_category();
+                if ( $display_category ) {
+                        $first_cat_id = $display_category->term_id;
+                } else {
+                        $default_cat = 0;
+                }
 		$blog_name    = get_bloginfo( 'description' );
 		$text_related = sprintf(
 			// translators: %s: Last articles.

--- a/single.php
+++ b/single.php
@@ -27,32 +27,23 @@ get_header();
 				</span>
 
 					<?php
-					// Get the post categories.
-					$categories = get_the_category();
+                                        $display_category = smile_v6_get_display_category();
 
-					if ( ! empty( $categories ) ) {
-						// Filter the categories to exclude the "Uncategorized" category.
-						$filtered_categories = array_filter(
-							$categories,
-							function ( $category ) {
-								return 'uncategorized' !== $category->slug;
-							}
-						);
-
-						if ( ! empty( $filtered_categories ) ) {
-							echo '<ul class="post-categories">';
-							foreach ( $filtered_categories as $category ) {
-								echo '<li>' . esc_html( $category->name ) . '</li>';
-							}
-							echo '</ul>';
-						} else {
-							// Show "Uncategorized" if there are no categories.
-							echo '<span>' . esc_html__( 'Uncategorized', 'smile-web' ) . '</span>';
-						}
-					} else {
-						// Show "Uncategorized" if there are no categories.
-						echo '<span>' . esc_html__( 'Uncategorized', 'smile-web' ) . '</span>';
-					}
+                                        if ( $display_category ) {
+                                                if ( 'uncategorized' === $display_category->slug ) {
+                                                        echo '<span>' . esc_html__( 'Uncategorized', 'smile-web' ) . '</span>';
+                                                } else {
+                                                        echo '<ul class="post-categories">';
+                                                        printf(
+                                                                '<li><a href="%1$s">%2$s</a></li>',
+                                                                esc_url( get_category_link( $display_category->term_id ) ),
+                                                                esc_html( $display_category->name )
+                                                        );
+                                                        echo '</ul>';
+                                                }
+                                        } else {
+                                                echo '<span>' . esc_html__( 'Uncategorized', 'smile-web' ) . '</span>';
+                                        }
 					?>
 
 					<?php if ( get_comments_number() > 0 ) : ?>
@@ -103,10 +94,16 @@ get_header();
 					</li>
 					<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 						<?php
-						$categories = get_the_category();
-						foreach ( $categories as $category ) {
-								echo '<a itemid="' . esc_attr( $category->cat_name ) . '" href="' . esc_url( get_category_link( $category->term_id ) ) . '"><span>' . esc_html( $category->cat_name ) . '</span></a>';
-						}
+                                                $display_category = smile_v6_get_display_category();
+                                                if ( $display_category ) {
+                                                        if ( 'uncategorized' === $display_category->slug ) {
+                                                                echo '<span>' . esc_html__( 'Uncategorized', 'smile-web' ) . '</span>';
+                                                        } else {
+                                                                echo '<a itemid="' . esc_attr( $display_category->cat_name ) . '" href="' . esc_url( get_category_link( $display_category->term_id ) ) . '"><span>' . esc_html( $display_category->cat_name ) . '</span></a>';
+                                                        }
+                                                } else {
+                                                        echo '<span>' . esc_html__( 'Uncategorized', 'smile-web' ) . '</span>';
+                                                }
 						?>
 						<meta itemprop="position" content="2" />
 					</li>
@@ -166,13 +163,9 @@ get_header();
 	<?php
 		/* if is sinlge && are posts */
 
-	if ( is_single() ) {
-		$categories = get_the_category();
-		if ( ! empty( $categories ) ) {
-			$category_id = $categories[0]->term_id; // ID first category.
-		} else {
-			$category_id = 0; // If there are no categories, then the ID is 0.
-		}
+        if ( is_single() ) {
+                $display_category = smile_v6_get_display_category();
+                $category_id      = $display_category ? $display_category->term_id : 0;
 
 			$current_post_id = get_the_ID();
 			$args            = array(
@@ -185,9 +178,14 @@ get_header();
 		<div class="container py-5">
 			<p class="text-emphasis col-md-12 mb-5 border-bottom"><?php echo esc_html__( 'Related articles', 'smile-web' ); ?>
 				<?php
-				$categories = get_the_category();
-				foreach ( $categories as $category ) {
-					echo '<a href="' . esc_url( get_category_link( $category->term_id ) ) . '">' . esc_html( $category->cat_name ) . '</a>';}
+                                $display_category = smile_v6_get_display_category();
+                                if ( $display_category ) {
+                                        if ( 'uncategorized' === $display_category->slug ) {
+                                                echo '<span>' . esc_html__( 'Uncategorized', 'smile-web' ) . '</span>';
+                                        } else {
+                                                echo '<a href="' . esc_url( get_category_link( $display_category->term_id ) ) . '">' . esc_html( $display_category->cat_name ) . '</a>';
+                                        }
+                                }
 				?>
 			</p>
 			<br>

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -36,12 +36,8 @@
 
 		<!-- Related articles -->
 			<?php
-			$categories = get_the_category(); // Obtains the categories of the current post.
-			if ( ! empty( $categories ) ) {
-				$category_id = $categories[0]->term_id; // ID of the first category.
-			} else {
-				$category_id = 0; // If there are no categories, the ID is 0.
-			}
+                        $display_category = smile_v6_get_display_category();
+                        $category_id      = $display_category ? $display_category->term_id : 0;
 
 			$current_post_id = get_the_ID(); // ID of the current post.
 			$args            = array(
@@ -66,15 +62,13 @@
                                 <article class="blog-col col-md-6 mb-4 mx-0">
                                         <div class="category shadow rounded">
                                                 <?php
-                                                $categories = get_the_category();
-                                                if ( $categories ) {
-                                                        foreach ( $categories as $category ) {
-                                                                printf(
-                                                                        '<a href="%1$s">%2$s</a>',
-                                                                        esc_url( get_category_link( $category->term_id ) ),
-                                                                        esc_html( $category->name )
-                                                                );
-                                                        }
+                                                $display_category = smile_v6_get_display_category();
+                                                if ( $display_category ) {
+                                                        printf(
+                                                                '<a href="%1$s">%2$s</a>',
+                                                                esc_url( get_category_link( $display_category->term_id ) ),
+                                                                esc_html( $display_category->name )
+                                                        );
                                                 }
                                                 ?>
                                         </div>


### PR DESCRIPTION
## Summary
- add a reusable `smile_v6_get_display_category()` helper to pick the category that should appear publicly
- update the front page, blog index, empty results, and single templates to render only one category badge/link
- align related-post queries and entry footer output with the selected display category for consistency

## Testing
- php -l inc/template-tags.php
- php -l front-page.php
- php -l index.php
- php -l template-parts/content-none.php
- php -l single.php
- php -l page-sidebar.php

------
https://chatgpt.com/codex/tasks/task_e_68d3ffb7c7788330b2e12174e79e834e