### PR TITLE
Improve colors import file upload validation

### DIFF
--- a/inc/color-management.php
+++ b/inc/color-management.php
@@ -284,7 +284,7 @@ function smile_v6_ajax_import_colors() {
 	}
 
 	// Validate file upload.
-	if ( ! isset( $_FILES['colors_file'] ) || $_FILES['colors_file']['error'] !== UPLOAD_ERR_OK ) {
+	if ( ! isset( $_FILES['colors_file'], $_FILES['colors_file']['error'] ) || UPLOAD_ERR_OK !== (int) $_FILES['colors_file']['error'] ) {
 		wp_send_json_error( array( 'message' => esc_html__( 'File upload failed.', 'smile-web' ) ) );
 		wp_die();
 	}


### PR DESCRIPTION
## Summary
- strengthen the import colors upload validation by verifying the presence of the file error field and comparing it against UPLOAD_ERR_OK

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdbb1d5f88330b72557f13025f475