### PR TITLE
Use UTC timestamp for exported color filenames

### DIFF
--- a/inc/color-management.php
+++ b/inc/color-management.php
@@ -248,7 +248,7 @@ function smile_v6_ajax_export_colors() {
 
 	// Set headers for file download.
 	header( 'Content-Type: application/json' );
-	header( 'Content-Disposition: attachment; filename="smile-web-colors-' . date( 'Y-m-d-H-i-s' ) . '.json"' );
+        header( 'Content-Disposition: attachment; filename="smile-web-colors-' . gmdate( 'Y-m-d-H-i-s' ) . '.json"' );
 	header( 'Cache-Control: no-cache, must-revalidate' );
 	header( 'Expires: Sat, 26 Jul 1997 05:00:00 GMT' );
 


### PR DESCRIPTION
## Summary
- ensure the exported color palette filename uses a UTC timestamp via `gmdate()` to avoid timezone differences

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbe38d67488330a418d0c020c56302