### PR TITLE
Guard custom Customizer controls against missing base class

### DIFF
--- a/inc/customizer/class-smile-web-export-control.php
+++ b/inc/customizer/class-smile-web-export-control.php
@@ -12,34 +12,40 @@
  *
  * @package smile-web
  */
-class Smile_Web_Export_Control extends WP_Customize_Control {
-	/**
-	 * Control type identifier.
-	 *
-	 * @since 6.0.7
-	 *
-	 * @var string
-	 */
-	public $type = 'export';
+if ( ! class_exists( 'WP_Customize_Control' ) ) {
+	require_once ABSPATH . 'wp-includes/class-wp-customize-control.php';
+}
 
-	/**
-	 * Renders the control content.
-	 *
-	 * @since 6.0.7
-	 *
-	 * @return void
-	 */
-	protected function render_content() {
-		?>
-		<label>
-			<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
-			<?php if ( ! empty( $this->description ) ) : ?>
-				<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
-			<?php endif; ?>
-		</label>
-		<button type="button" class="button smile-v6-export-colors">
-			<?php esc_html_e( 'Download Colors JSON', 'smile-web' ); ?>
-		</button>
-		<?php
+if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Export_Control' ) ) {
+	class Smile_Web_Export_Control extends WP_Customize_Control {
+		/**
+		 * Control type identifier.
+		 *
+		 * @since 6.0.7
+		 *
+		 * @var string
+		 */
+		public $type = 'export';
+
+		/**
+		 * Renders the control content.
+		 *
+		 * @since 6.0.7
+		 *
+		 * @return void
+		 */
+		protected function render_content() {
+			?>
+			<label>
+				<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+				<?php if ( ! empty( $this->description ) ) : ?>
+					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
+				<?php endif; ?>
+			</label>
+			<button type="button" class="button smile-v6-export-colors">
+				<?php esc_html_e( 'Download Colors JSON', 'smile-web' ); ?>
+			</button>
+			<?php
+		}
 	}
 }

--- a/inc/customizer/class-smile-web-import-control.php
+++ b/inc/customizer/class-smile-web-import-control.php
@@ -12,36 +12,42 @@
  *
  * @package smile-web
  */
-class Smile_Web_Import_Control extends WP_Customize_Control {
-	/**
-	 * Control type identifier.
-	 *
-	 * @since 6.0.7
-	 *
-	 * @var string
-	 */
-	public $type = 'import';
+if ( ! class_exists( 'WP_Customize_Control' ) ) {
+	require_once ABSPATH . 'wp-includes/class-wp-customize-control.php';
+}
 
-	/**
-	 * Renders the control content.
-	 *
-	 * @since 6.0.7
-	 *
-	 * @return void
-	 */
-	protected function render_content() {
-		?>
-		<label>
-			<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
-			<?php if ( ! empty( $this->description ) ) : ?>
-				<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
-			<?php endif; ?>
-		</label>
-		<input type="file" class="smile-v6-import-file" accept=".json" />
-		<button type="button" class="button smile-v6-import-colors" disabled>
-			<?php esc_html_e( 'Import Colors', 'smile-web' ); ?>
-		</button>
-		<div class="smile-v6-import-status smile-v6-status"></div>
-		<?php
+if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Import_Control' ) ) {
+	class Smile_Web_Import_Control extends WP_Customize_Control {
+		/**
+		 * Control type identifier.
+		 *
+		 * @since 6.0.7
+		 *
+		 * @var string
+		 */
+		public $type = 'import';
+
+		/**
+		 * Renders the control content.
+		 *
+		 * @since 6.0.7
+		 *
+		 * @return void
+		 */
+		protected function render_content() {
+			?>
+			<label>
+				<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+				<?php if ( ! empty( $this->description ) ) : ?>
+					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
+				<?php endif; ?>
+			</label>
+			<input type="file" class="smile-v6-import-file" accept=".json" />
+			<button type="button" class="button smile-v6-import-colors" disabled>
+				<?php esc_html_e( 'Import Colors', 'smile-web' ); ?>
+			</button>
+			<div class="smile-v6-import-status smile-v6-status"></div>
+			<?php
+		}
 	}
 }

--- a/inc/customizer/class-smile-web-reset-control.php
+++ b/inc/customizer/class-smile-web-reset-control.php
@@ -12,35 +12,41 @@
  *
  * @package smile-web
  */
-class Smile_Web_Reset_Control extends WP_Customize_Control {
-	/**
-	 * Control type identifier.
-	 *
-	 * @since 6.0.7
-	 *
-	 * @var string
-	 */
-	public $type = 'reset';
+if ( ! class_exists( 'WP_Customize_Control' ) ) {
+	require_once ABSPATH . 'wp-includes/class-wp-customize-control.php';
+}
 
-	/**
-	 * Renders the control content.
-	 *
-	 * @since 6.0.7
-	 *
-	 * @return void
-	 */
-	protected function render_content() {
-		?>
-		<label>
-			<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
-			<?php if ( ! empty( $this->description ) ) : ?>
-				<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
-			<?php endif; ?>
-		</label>
-		<button type="button" class="button smile-v6-reset-colors">
-			<?php esc_html_e( 'Reset All Colors', 'smile-web' ); ?>
-		</button>
-		<div class="smile-v6-reset-status smile-v6-status"></div>
-		<?php
+if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Reset_Control' ) ) {
+	class Smile_Web_Reset_Control extends WP_Customize_Control {
+		/**
+		 * Control type identifier.
+		 *
+		 * @since 6.0.7
+		 *
+		 * @var string
+		 */
+		public $type = 'reset';
+
+		/**
+		 * Renders the control content.
+		 *
+		 * @since 6.0.7
+		 *
+		 * @return void
+		 */
+		protected function render_content() {
+			?>
+			<label>
+				<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+				<?php if ( ! empty( $this->description ) ) : ?>
+					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
+				<?php endif; ?>
+			</label>
+			<button type="button" class="button smile-v6-reset-colors">
+				<?php esc_html_e( 'Reset All Colors', 'smile-web' ); ?>
+			</button>
+			<div class="smile-v6-reset-status smile-v6-status"></div>
+			<?php
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- ensure each Color Management Customizer control requires the core `WP_Customize_Control` class when absent
- wrap the export, import, and reset control definitions so they only load once the base class is available

## Testing
- php -l inc/customizer/class-smile-web-export-control.php
- php -l inc/customizer/class-smile-web-import-control.php
- php -l inc/customizer/class-smile-web-reset-control.php

------
https://chatgpt.com/codex/tasks/task_e_68dbea9981788330b6c3147a1d378fa4