### PR TITLE
Fix Customizer color management control loading

### DIFF
--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -5,10 +5,6 @@
  * @package smile-web
  */
 
-require_once __DIR__ . '/customizer/class-smile-web-export-control.php';
-require_once __DIR__ . '/customizer/class-smile-web-import-control.php';
-require_once __DIR__ . '/customizer/class-smile-web-reset-control.php';
-
 /**
  * Sanitize opacity values for rgba colors.
  *
@@ -1428,9 +1424,13 @@ add_action( 'customize_register', 'smile_v6_customize_front_page_intro_section' 
  * @return void
  */
 function smile_v6_register_custom_controls( $wp_customize ) {
-		$wp_customize->register_control_type( 'Smile_Web_Export_Control' );
-		$wp_customize->register_control_type( 'Smile_Web_Import_Control' );
-		$wp_customize->register_control_type( 'Smile_Web_Reset_Control' );
+	require_once __DIR__ . '/customizer/class-smile-web-export-control.php';
+	require_once __DIR__ . '/customizer/class-smile-web-import-control.php';
+	require_once __DIR__ . '/customizer/class-smile-web-reset-control.php';
+
+	$wp_customize->register_control_type( 'Smile_Web_Export_Control' );
+	$wp_customize->register_control_type( 'Smile_Web_Import_Control' );
+	$wp_customize->register_control_type( 'Smile_Web_Reset_Control' );
 }
 add_action( 'customize_register', 'smile_v6_register_custom_controls', 1 );
 


### PR DESCRIPTION
## Summary
- remove early includes of the color management customizer controls
- load the control class files within the customizer hook before registering the control types

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbf4d7b3288330b6af6f6d09880d7d