### PR TITLE
Load customizer control classes during theme bootstrap

### DIFF
--- a/inc/customizer-options.php
+++ b/inc/customizer-options.php
@@ -5,6 +5,10 @@
  * @package smile-web
  */
 
+require_once __DIR__ . '/customizer/class-smile-web-export-control.php';
+require_once __DIR__ . '/customizer/class-smile-web-import-control.php';
+require_once __DIR__ . '/customizer/class-smile-web-reset-control.php';
+
 /**
  * Sanitize opacity values for rgba colors.
  *
@@ -1171,18 +1175,20 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 						'sanitize_callback' => 'wp_kses_post',
 					)
 				);
-	$wp_customize->add_control(
-		new Smile_Web_Export_Control(
-			$wp_customize,
-			'smile_v6_export_colors',
-			array(
-				'label'       => esc_html__( 'Export Color Settings', 'smile-web' ),
-				'description' => esc_html__( 'Download your current color settings as a JSON file.', 'smile-web' ),
-				'section'     => 'custom_theme_color_management',
-				'type'        => 'export',
-			)
-		)
-	);
+        if ( class_exists( 'Smile_Web_Export_Control' ) ) {
+                $wp_customize->add_control(
+                        new Smile_Web_Export_Control(
+                                $wp_customize,
+                                'smile_v6_export_colors',
+                                array(
+                                        'label'       => esc_html__( 'Export Color Settings', 'smile-web' ),
+                                        'description' => esc_html__( 'Download your current color settings as a JSON file.', 'smile-web' ),
+                                        'section'     => 'custom_theme_color_management',
+                                        'type'        => 'export',
+                                )
+                        )
+                );
+        }
 
 	// Import Colors File Upload.
 	$wp_customize->add_setting(
@@ -1191,18 +1197,20 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 			'sanitize_callback' => 'wp_kses_post',
 		)
 	);
-	$wp_customize->add_control(
-		new Smile_Web_Import_Control(
-			$wp_customize,
-			'smile_v6_import_colors',
-			array(
-				'label'       => esc_html__( 'Import Color Settings', 'smile-web' ),
-				'description' => esc_html__( 'Upload a JSON file to import color settings.', 'smile-web' ),
-				'section'     => 'custom_theme_color_management',
-				'type'        => 'import',
-			)
-		)
-	);
+        if ( class_exists( 'Smile_Web_Import_Control' ) ) {
+                $wp_customize->add_control(
+                        new Smile_Web_Import_Control(
+                                $wp_customize,
+                                'smile_v6_import_colors',
+                                array(
+                                        'label'       => esc_html__( 'Import Color Settings', 'smile-web' ),
+                                        'description' => esc_html__( 'Upload a JSON file to import color settings.', 'smile-web' ),
+                                        'section'     => 'custom_theme_color_management',
+                                        'type'        => 'import',
+                                )
+                        )
+                );
+        }
 
 	// Reset Colors Button.
 	$wp_customize->add_setting(
@@ -1211,18 +1219,20 @@ function smile_v6_customize_theme_sections( $wp_customize ) {
 			'sanitize_callback' => 'wp_kses_post',
 		)
 	);
-	$wp_customize->add_control(
-		new Smile_Web_Reset_Control(
-			$wp_customize,
-			'smile_v6_reset_colors',
-			array(
-				'label'       => esc_html__( 'Reset to Ocean Professional', 'smile-web' ),
-				'description' => esc_html__( 'Reset all colors to the default Ocean Professional palette.', 'smile-web' ),
-				'section'     => 'custom_theme_color_management',
-				'type'        => 'reset',
-			)
-		)
-	);
+        if ( class_exists( 'Smile_Web_Reset_Control' ) ) {
+                $wp_customize->add_control(
+                        new Smile_Web_Reset_Control(
+                                $wp_customize,
+                                'smile_v6_reset_colors',
+                                array(
+                                        'label'       => esc_html__( 'Reset to Ocean Professional', 'smile-web' ),
+                                        'description' => esc_html__( 'Reset all colors to the default Ocean Professional palette.', 'smile-web' ),
+                                        'section'     => 'custom_theme_color_management',
+                                        'type'        => 'reset',
+                                )
+                        )
+                );
+        }
 }
 
 /**
@@ -1424,13 +1434,9 @@ add_action( 'customize_register', 'smile_v6_customize_front_page_intro_section' 
  * @return void
  */
 function smile_v6_register_custom_controls( $wp_customize ) {
-	require_once __DIR__ . '/customizer/class-smile-web-export-control.php';
-	require_once __DIR__ . '/customizer/class-smile-web-import-control.php';
-	require_once __DIR__ . '/customizer/class-smile-web-reset-control.php';
-
-	$wp_customize->register_control_type( 'Smile_Web_Export_Control' );
-	$wp_customize->register_control_type( 'Smile_Web_Import_Control' );
-	$wp_customize->register_control_type( 'Smile_Web_Reset_Control' );
+        $wp_customize->register_control_type( 'Smile_Web_Export_Control' );
+        $wp_customize->register_control_type( 'Smile_Web_Import_Control' );
+        $wp_customize->register_control_type( 'Smile_Web_Reset_Control' );
 }
 add_action( 'customize_register', 'smile_v6_register_custom_controls', 1 );
 


### PR DESCRIPTION
## Summary
- load the custom color management controls when the customizer options file is loaded
- keep control registration on the customize_register hook while guarding instantiation with class_exists checks

## Testing
- php -l inc/customizer-options.php

------
https://chatgpt.com/codex/tasks/task_e_68dce32af11c8330a5f73d71b604b0de