### PR TITLE
Ensure color management controls attach to settings

### DIFF
--- a/inc/customizer/class-smile-web-export-control.php
+++ b/inc/customizer/class-smile-web-export-control.php
@@ -42,6 +42,7 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Export
 					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
 				<?php endif; ?>
 			</label>
+			<input type="hidden" <?php $this->link(); ?> value="" />
 			<button type="button" class="button smile-v6-export-colors">
 				<?php esc_html_e( 'Download Colors JSON', 'smile-web' ); ?>
 			</button>

--- a/inc/customizer/class-smile-web-import-control.php
+++ b/inc/customizer/class-smile-web-import-control.php
@@ -42,6 +42,7 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Import
 					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
 				<?php endif; ?>
 			</label>
+			<input type="hidden" <?php $this->link(); ?> value="" />
 			<input type="file" class="smile-v6-import-file" accept=".json" />
 			<button type="button" class="button smile-v6-import-colors" disabled>
 				<?php esc_html_e( 'Import Colors', 'smile-web' ); ?>

--- a/inc/customizer/class-smile-web-reset-control.php
+++ b/inc/customizer/class-smile-web-reset-control.php
@@ -42,6 +42,7 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Reset_
 					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
 				<?php endif; ?>
 			</label>
+			<input type="hidden" <?php $this->link(); ?> value="" />
 			<button type="button" class="button smile-v6-reset-colors">
 				<?php esc_html_e( 'Reset All Colors', 'smile-web' ); ?>
 			</button>


### PR DESCRIPTION
## Summary
- add hidden inputs to the export, import, and reset customizer controls so they bind to their settings without changing the UI

## Testing
- php -l inc/customizer/class-smile-web-export-control.php
- php -l inc/customizer/class-smile-web-import-control.php
- php -l inc/customizer/class-smile-web-reset-control.php

------
https://chatgpt.com/codex/tasks/task_e_68dd071e6acc8330b63fddb78eace7f3