### PR TITLE
Ensure Customizer controls retain stored values

### DIFF
--- a/inc/customizer/class-smile-web-export-control.php
+++ b/inc/customizer/class-smile-web-export-control.php
@@ -42,7 +42,7 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Export
 					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
 				<?php endif; ?>
 			</label>
-			<input type="hidden" <?php $this->link(); ?> value="" />
+                        <input type="hidden" <?php $this->link(); ?> value="<?php echo esc_attr( $this->value() ); ?>" />
 			<button type="button" class="button smile-v6-export-colors">
 				<?php esc_html_e( 'Download Colors JSON', 'smile-web' ); ?>
 			</button>

--- a/inc/customizer/class-smile-web-import-control.php
+++ b/inc/customizer/class-smile-web-import-control.php
@@ -42,7 +42,7 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Import
 					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
 				<?php endif; ?>
 			</label>
-			<input type="hidden" <?php $this->link(); ?> value="" />
+                        <input type="hidden" <?php $this->link(); ?> value="<?php echo esc_attr( $this->value() ); ?>" />
 			<input type="file" class="smile-v6-import-file" accept=".json" />
 			<button type="button" class="button smile-v6-import-colors" disabled>
 				<?php esc_html_e( 'Import Colors', 'smile-web' ); ?>

--- a/inc/customizer/class-smile-web-reset-control.php
+++ b/inc/customizer/class-smile-web-reset-control.php
@@ -42,7 +42,7 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Reset_
 					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
 				<?php endif; ?>
 			</label>
-			<input type="hidden" <?php $this->link(); ?> value="" />
+                        <input type="hidden" <?php $this->link(); ?> value="<?php echo esc_attr( $this->value() ); ?>" />
 			<button type="button" class="button smile-v6-reset-colors">
 				<?php esc_html_e( 'Reset All Colors', 'smile-web' ); ?>
 			</button>


### PR DESCRIPTION
## Summary
- update the hidden field values in the Customizer export, import, and reset controls to use the stored setting value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd0d41e880833099c4553b4eadac36