### PR TITLE
Add JS templates for color management customizer controls

### DIFF
--- a/inc/customizer/class-smile-web-export-control.php
+++ b/inc/customizer/class-smile-web-export-control.php
@@ -34,19 +34,43 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Export
 		 *
 		 * @return void
 		 */
-		protected function render_content() {
-			?>
-			<label>
-				<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
-				<?php if ( ! empty( $this->description ) ) : ?>
-					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
-				<?php endif; ?>
-			</label>
+                protected function render_content() {
+                        ?>
+                        <label>
+                                <span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+                                <?php if ( ! empty( $this->description ) ) : ?>
+                                        <span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
+                                <?php endif; ?>
+                        </label>
                         <input type="hidden" <?php $this->link(); ?> value="<?php echo esc_attr( $this->value() ); ?>" />
-			<button type="button" class="button smile-v6-export-colors">
-				<?php esc_html_e( 'Download Colors JSON', 'smile-web' ); ?>
-			</button>
-			<?php
-		}
-	}
+                        <button type="button" class="button smile-v6-export-colors">
+                                <?php esc_html_e( 'Download Colors JSON', 'smile-web' ); ?>
+                        </button>
+                        <?php
+                }
+
+                /**
+                 * Outputs the Underscore.js template for the control content.
+                 *
+                 * @since 6.0.7
+                 *
+                 * @return void
+                 *
+                 * @package smile-web
+                 */
+                public function content_template() {
+                        ?>
+                        <label>
+                                <span class="customize-control-title">{{ data.label }}</span>
+                                <# if ( data.description ) { #>
+                                        <span class="description customize-control-description">{{{ data.description }}}</span>
+                                <# } #>
+                        </label>
+                        <input type="hidden" {{{ data.link }}} value="{{ data.value }}" />
+                        <button type="button" class="button smile-v6-export-colors">
+                                <?php esc_html_e( 'Download Colors JSON', 'smile-web' ); ?>
+                        </button>
+                        <?php
+                }
+        }
 }

--- a/inc/customizer/class-smile-web-import-control.php
+++ b/inc/customizer/class-smile-web-import-control.php
@@ -34,11 +34,11 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Import
 		 *
 		 * @return void
 		 */
-		protected function render_content() {
-			?>
-			<label>
-				<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
-				<?php if ( ! empty( $this->description ) ) : ?>
+                protected function render_content() {
+                        ?>
+                        <label>
+                                <span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+                                <?php if ( ! empty( $this->description ) ) : ?>
 					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
 				<?php endif; ?>
 			</label>
@@ -47,8 +47,34 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Import
 			<button type="button" class="button smile-v6-import-colors" disabled>
 				<?php esc_html_e( 'Import Colors', 'smile-web' ); ?>
 			</button>
-			<div class="smile-v6-import-status smile-v6-status"></div>
-			<?php
-		}
-	}
+                        <div class="smile-v6-import-status smile-v6-status"></div>
+                        <?php
+                }
+
+                /**
+                 * Outputs the Underscore.js template for the control content.
+                 *
+                 * @since 6.0.7
+                 *
+                 * @return void
+                 *
+                 * @package smile-web
+                 */
+                public function content_template() {
+                        ?>
+                        <label>
+                                <span class="customize-control-title">{{ data.label }}</span>
+                                <# if ( data.description ) { #>
+                                        <span class="description customize-control-description">{{{ data.description }}}</span>
+                                <# } #>
+                        </label>
+                        <input type="hidden" {{{ data.link }}} value="{{ data.value }}" />
+                        <input type="file" class="smile-v6-import-file" accept=".json" />
+                        <button type="button" class="button smile-v6-import-colors" disabled>
+                                <?php esc_html_e( 'Import Colors', 'smile-web' ); ?>
+                        </button>
+                        <div class="smile-v6-import-status smile-v6-status"></div>
+                        <?php
+                }
+        }
 }

--- a/inc/customizer/class-smile-web-reset-control.php
+++ b/inc/customizer/class-smile-web-reset-control.php
@@ -34,11 +34,11 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Reset_
 		 *
 		 * @return void
 		 */
-		protected function render_content() {
-			?>
-			<label>
-				<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
-				<?php if ( ! empty( $this->description ) ) : ?>
+                protected function render_content() {
+                        ?>
+                        <label>
+                                <span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+                                <?php if ( ! empty( $this->description ) ) : ?>
 					<span class="description customize-control-description"><?php echo esc_html( $this->description ); ?></span>
 				<?php endif; ?>
 			</label>
@@ -46,8 +46,33 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Smile_Web_Reset_
 			<button type="button" class="button smile-v6-reset-colors">
 				<?php esc_html_e( 'Reset All Colors', 'smile-web' ); ?>
 			</button>
-			<div class="smile-v6-reset-status smile-v6-status"></div>
-			<?php
-		}
-	}
+                        <div class="smile-v6-reset-status smile-v6-status"></div>
+                        <?php
+                }
+
+                /**
+                 * Outputs the Underscore.js template for the control content.
+                 *
+                 * @since 6.0.7
+                 *
+                 * @return void
+                 *
+                 * @package smile-web
+                 */
+                public function content_template() {
+                        ?>
+                        <label>
+                                <span class="customize-control-title">{{ data.label }}</span>
+                                <# if ( data.description ) { #>
+                                        <span class="description customize-control-description">{{{ data.description }}}</span>
+                                <# } #>
+                        </label>
+                        <input type="hidden" {{{ data.link }}} value="{{ data.value }}" />
+                        <button type="button" class="button smile-v6-reset-colors">
+                                <?php esc_html_e( 'Reset All Colors', 'smile-web' ); ?>
+                        </button>
+                        <div class="smile-v6-reset-status smile-v6-status"></div>
+                        <?php
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- add `content_template` implementations for the export, import, and reset color controls
- mirror the existing control markup with Underscore templating to support live rendering in the Customizer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd1f54667c8330a17940f4707750df